### PR TITLE
Add RSS feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -4,8 +4,8 @@
     <atom:link href="https://swiftunwrapped.github.io/feed.xml" rel="self" type="application/atom+xml" />
 
     <title>Swift Unwrapped</title>
-    <description>An audio spin off of Swift Weekly Brief and discussions on the Swift programming language. </description>
-    <copyright>2020 Spec Network, Inc.</copyright>
+    <description>Discussions on the Swift programming language and other projects at Swift.org</description>
+    <copyright>2020 JP Simard, Jesse Squires, Spec Network, Inc.</copyright>
     <language>en</language>
     <pubDate>Mon, 21 Jun 2021 12:00:00 +0000</pubDate>
     <lastBuildDate>Mon, 21 Jun 2021 12:00:10 +0000</lastBuildDate>

--- a/feed.xml
+++ b/feed.xml
@@ -10,11 +10,11 @@
     <pubDate>Mon, 21 Jun 2021 12:00:00 +0000</pubDate>
     <lastBuildDate>Mon, 21 Jun 2021 12:00:10 +0000</lastBuildDate>
     <image>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <title>Swift Unwrapped</title>
       <url>https://image.simplecastcdn.com/images/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a28195f8-ab73-4040-90cf-6b0ff94bf477/3000x3000/1557116952-artwork.jpg?aid=rss_feed</url>
     </image>
-    <link>https://spec.fm/podcasts/swift-unwrapped</link>
+    <link>https://swiftunwrapped.github.io</link>
     <itunes:type>episodic</itunes:type>
     <itunes:summary>An audio spin off of Swift Weekly Brief and discussions on the Swift programming language. </itunes:summary>
     <itunes:author>Spec, JP Simard, Jesse Squires</itunes:author>
@@ -34,7 +34,7 @@
 ]]></description>
       <pubDate>Mon, 21 Jun 2021 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec Network, Inc.)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul><li><a href="https://www.hackingwithswift.com/articles/233/whats-new-in-swift-5-5">Paul Hudson's What's New in Swift 5.5</a></li><li><a href="https://swiftbysundell.com/">Swift By Sundell</a></li><li><a href="https://github.com/davedelong/time">Time by Dave DeLong</a> (mistakenly called Chronos during the show)</li></ul>
 ]]></content:encoded>
       <enclosure length="27800880" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/9415a7c4-e767-4bc1-8438-e67ff03a542c/audio/59932e5c-d516-4f64-9e02-b1923f03261d/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
@@ -59,7 +59,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 7 Dec 2020 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec Network, Inc.)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>Links</h3><ul><li><a href="https://forums.swift.org/t/swift-concurrency-roadmap/41611">Swift concurrency roadmap</a></li><li><a href="https://swiftunwrapped.github.io/episodes/409cbdc5/">Episode 27: Concurrency with Chris Lattner</a></li><li><a href="https://forums.swift.org/t/concurrency-actors-actor-isolation/41613">[Concurrency] Actors & actor isolation</a></li><li><a href="https://forums.swift.org/t/concurrency-interoperability-with-objective-c/41616">[Concurrency] Interoperability with Objective-C</a></li><li><a href="https://forums.swift.org/t/concurrency-structured-concurrency/41622">[Concurrency] Structured concurrency</a></li><li><a href="https://forums.swift.org/t/concurrency-asynchronous-functions/41619">[Concurrency] Asynchronous functions</a></li><li><a href="https://forums.swift.org/t/concurrency-asyncsequence/42417">[Concurrency] AsyncSequence</a></li><li><a href="https://gist.github.com/DougGregor/444575ac67cbd25bfc4b1d4fd241ae93">Swift Concurrency Proposals Dependencies Graph</a></li><li><a href="https://docs.google.com/document/d/1BEO6QwzcYCUhaGyA-WRoM_phRa7O7mGPNIMdSV4StEE">Protocol-based Actor Isolation: Draft #2</a></li><li><a href="https://forums.swift.org/t/actors-are-reference-types-but-why-classes/42281">Actors are reference types, but why classes?</a></li></ul><h3>Sponsors</h3><ul><li><strong>AWS Amplify</strong> - AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 ]]></content:encoded>
       <enclosure length="43224292" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/0248870d-280f-4df1-8693-c659a1210f4d/audio/1e27b922-a9a5-4678-9203-a539ef1f7b58/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
@@ -80,7 +80,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 2 Nov 2020 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec Network, Inc.)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>Links</h3><ul><li><a href="https://swift.org/blog/swift-atomics/">Announcement blog post</a></li><li><a href="https://twitter.com/lorentey/">Karoy Lorentey</a></li><li><a href="https://github.com/apple/swift-atomics">GitHub Repository</a></li><li><a href="https://forums.swift.org/c/related-projects/swift-atomics">Atomics forum</a></li><li><a href="https://news.ycombinator.com/item?id=24657500">Hacker News Discussion</a></li><li><a href="https://github.com/glessard/swift-atomics">Guillaume Lessard’s existing swift-atomics repo</a></li></ul><h3>Sponsors</h3><ul><li><strong>AWS Amplify</strong> - AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a>.</p>
 ]]></content:encoded>
       <enclosure length="26140572" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/0d6319c6-d943-4a47-9eb0-cd58829472a8/audio/d75cc258-b633-4807-839b-49c17dc299c1/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
@@ -101,7 +101,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 12 Oct 2020 18:10:30 +0000</pubDate>
       <author>shows@spec.fm (Spec Network, Inc.)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>What’s in a Swift runtime?</h2><ul><li><a href="https://belkadan.com/blog/2020/04/Swift-on-Mac-OS-9/">Swift on Mac OS 9</a></li><li><a href="https://belkadan.com/blog/2020/08/Swift-Runtime-Heap-Objects/">Heap Objects</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Type-Layout/">Type Layout</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Type-Metadata/">Type Metadata</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Uniquing-Caches/">Uniquing Caches</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Class-Metadata/">Class Metadata</a></li><li><a href="https://belkadan.com/blog/2020/10/Swift-Runtime-Class-Metadata-Initialization/">Class Metadata Initialization</a></li></ul><h3>Other links</h3><ul><li><a href="https://forums.swift.org/t/guarantee-in-memory-tuple-layout-or-dont/40122">Layout guarantees</a></li><li><a href="https://www.highcaffeinecontent.com/blog/20150124-MPW,-Carbon-and-building-Classic-Mac-OS-apps-in-OS-X">Steve Troughton-Smith’s BitPaint</a></li><li><a href="https://github.com/ksherlock/mpw">@ksherlock’s mpw</a></li><li><a href="https://mikeash.com/pyblog/friday-qa-2017-09-22-swift-4-weak-references.html">An explainer on Swift weak references</a></li></ul><h3>About Jordan</h3><ul><li><a href="https://twitter.com/UINT_MIN">Twitter @UINT_MIN</a></li><li><a href="https://belkadan.com">Belkadan</a></li><li><a href="https://citizensclimatelobby.org">Citizens’ Climate Lobby</a></li></ul><h3> </h3><h3>Sponsors</h3><ul><li><strong>Instabug</strong> - Get Application Performance Monitoring built for mobile apps and stay on top of your app quality with Instabug. Check them out and them them know we sent you at <a href="https://try.instabug.com/SwiftUnwrapped">https://try.instabug.com/SwiftUnwrapped</a></li></ul><p> </p><ul><li><strong>AWS Amplify </strong>- AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3> </h3><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a>.</p>
 ]]></content:encoded>
       <enclosure length="63787048" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/4eaaf04a-3e8b-4ab7-96ca-84e0f622062f/audio/92563d7e-1b47-4c64-8aa3-e04013fb02f9/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
@@ -122,7 +122,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 14 Sep 2020 17:26:37 +0000</pubDate>
       <author>shows@spec.fm (Spec Network, Inc.)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul><li><a href="https://swift.org/blog/5-3-release-process/">5.3 release process</a></li><li><a href="https://swift.org/blog/additional-linux-distros/">Swift for Linux distros</a></li><li><a href="https://swift.org/blog/aws-lambda-runtime/">AWS lambda Runtime</a></li><li><a href="https://swift.org/blog/swift-service-lifecycle/">Swift Service Lifecycle</a></li><li><a href="https://swift.org/blog/swift-cluster-membership/">Swift Cluster membership</a></li><li><a href="https://apple.github.io/swift-evolution/#?status=accepted&version=5.3">Proposals accepted/implemented in 5.3</a></li><li><a href="https://github.com/apple/swift/commits/release/5.3">Commit history for Swift 5.3 branch</a></li><li><a href="https://github.com/apple/swift/pull/33487">Mike Ash's perf PR</a></li><li><a href="https://www.hackingwithswift.com/articles/218/whats-new-in-swift-5-3">Hacking with Swift What’s New in Swift 5.3</a></li></ul><h2>Get in Touch</h2><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
       <enclosure length="17873749" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f66e20f0-f2e0-4aef-953b-3fbf60ea8dc8/88_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
@@ -143,7 +143,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 3 Aug 2020 12:00:06 +0000</pubDate>
       <author>shows@spec.fm (Spec Network, Inc.)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul><li>Swift Package Index<ul><li><a href="https://iosdevweekly.com/issues/460#comment">Intro</a></li><li><a href="https://swiftpackageindex.com">Website</a></li><li><a href="https://forums.swift.org/t/introducing-the-swift-package-index/37512">Forum</a></li><li><a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server">GitHub</a></li><li><a href="https://github.com/SwiftPackageIndex/PackageList">Package List</a></li><li><a href="https://twitter.com/daveverwer">Dave</a></li><li><a href="https://twitter.com/_sa_s">Sven</a></li><li><a href="https://cocoapods.org">CocoaPods website</a></li></ul></li><li>Swift Package Registry<ul><li><a href="https://forums.swift.org/t/swift-package-registry-service/37219">Swift Package Registry Service Pitch</a><ul><li><a href="https://twitter.com/mattt/status/1278706413921951746">Tweet</a></li></ul></li><li><a href="https://forums.swift.org/t/package-manager-source-archive-dependencies/38626">Package Manager Source Archive Dependencies Pitch</a><ul><li><a href="https://twitter.com/mattt/status/1285966688597315584">Tweet</a></li></ul></li><li><a href="https://twitter.com/mattt">Mattt Thompson</a></li></ul></li></ul><h2>Get in Touch</h2><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
       <enclosure length="34345134" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b6787f56-3a6d-43cb-884e-820a1028bba1/87_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
@@ -165,7 +165,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Thu, 18 Jun 2020 12:00:04 +0000</pubDate>
       <author>shows@spec.fm (Spec Network, Inc.)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h4>SE-0282 Tuples conform to Equatable, Comparable, and Hashable</h4><ul><li>Acceptance: <a href="https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658">https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658</a></li><li>Review: <a href="https://forums.swift.org/t/se-0283-tuples-conform-to-equatable-comparable-and-hashable/36140">https://forums.swift.org/t/se-0283-tuples-conform-to-equatable-comparable-and-hashable/36140</a></li><li>Proposal: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0283-tuples-are-equatable-comparable-hashable.md">https://github.com/apple/swift-evolution/blob/master/proposals/0283-tuples-are-equatable-comparable-hashable.md</a></li></ul><p>Bow: <a href="https://bow-swift.io">https://bow-swift.io</a></p><h3>👋 Get in Touch</h3><p>We are <a href="https://twitter.com/swift_unwrapped">@swift_unwrapped</a> on twitter. Follow us, ask us a question, let us know what you think of the show! If you want to follow us individually, we're <a href="https://twitter.com/jesse_squires">@jesse_squires</a> and <a href="https://twitter.com/simjp">@simjp</a>.</p><h3>🖤 Leave A Review</h3><p>If you're enjoying the show. The best and easiest way to show your support is by heading over to iTunes and leaving us a review! Not only do you let us know what you like about the show, but you're also helping other Swift language folks find the show.</p><p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
 ]]></content:encoded>
       <enclosure length="38973156" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/641073f1-f00c-4303-b83d-140a78ceab87/project-86v2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
@@ -201,7 +201,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Tue, 3 Mar 2020 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Foundation on Windows: https://forums.swift.org/t/swift-soars-ever-higher/34036</li>
 <li>Interoperability between Swift and C++: https://forums.swift.org/t/manifesto-interoperability-between-swift-and-c/33874</li>
@@ -251,7 +251,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 3 Feb 2020 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Magic file names: https://github.com/apple/swift-evolution/blob/master/proposals/0274-magic-file.md</li>
 <li>Multi-pattern catch clauses
@@ -294,7 +294,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 6 Jan 2020 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><a href="https://forums.swift.org/t/modify-accessors/31872">Forum post</a></li>
 <li><a href="https://www.youtube.com/watch?v=BXJIIQ-B4-E">Functional Swift conference talk</a></li>
@@ -336,7 +336,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 2 Dec 2019 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>The way Swift reports compilation diagnostics like errors, warnings and fixits is about to improve in Swift 5.2.</p>
 <ul>
 <li><a href="https://swift.org/blog/new-diagnostic-arch-overview/">Blog post</a></li>
@@ -386,7 +386,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 4 Nov 2019 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Would you like some Swift in your Swift? The compiler driver is getting a shiny new implementation in Swift and there's no shortage of opportunities to contribute.</p>
 <ul>
 <li><a href="https://forums.swift.org/t/new-project-announcement-swift-compiler-driver-reimplementation-in-swift/29696">Forum discussion</a></li>
@@ -438,7 +438,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 7 Oct 2019 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>The Swift of tomorrow... today! The Standard Library Preview Package would allow you to try out upcoming Swift features before they officially ship with new language versions.</p>
 <ul>
 <li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0264-stdlib-preview-package.md</li>
@@ -487,7 +487,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 16 Sep 2019 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Burritos: https://github.com/guillermomuntaner/Burritos</li>
 <li>SE-0260 Library Evolution: https://github.com/apple/swift-evolution/blob/master/proposals/0260-library-evolution.md</li>
@@ -533,7 +533,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 2 Sep 2019 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Forum pitch: https://forums.swift.org/t/pitch-support-for-binary-dependencies/27620</li>
 <li>Swift ABI Stability: https://swift.org/blog/abi-stability-and-more/</li>
@@ -582,7 +582,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 5 Aug 2019 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0246-mathable.md">Proposal SE-0246</a></li>
 <li><a href="https://speakerdeck.com/jessesquires/exploring-swifts-numeric-types-and-protocols">Exploring Swift's Numeric Types and Protocols</a></li>
@@ -642,7 +642,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 1 Jul 2019 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md">Proposal SE-0258</a></li>
 <li>Review threads:
@@ -707,7 +707,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Sun, 2 Jun 2019 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>Links</h2>
 <ul>
 <li><a href="https://github.com/yonaskolb/XcodeGen">XcodeGen</a></li>
@@ -771,7 +771,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 6 May 2019 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>Relevant Links</h2>
 <ul>
 <li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0255-omit-return.md">SE-0255: Implicit returns from single-expression functions</a>
@@ -833,7 +833,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 1 Apr 2019 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>Relevant Links</h2>
 <ul>
 <li><a href="https://swift.org/blog/utf8-string/">UTF-8 String blog post on swift.org</a></li>
@@ -896,7 +896,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 4 Mar 2019 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>Relevant Links</h2>
 <ul>
 <li><a href="https://forums.swift.org/t/pitch-an-official-style-guide-and-formatter-for-swift/21025">Swift Forums Pitch: an Official Style Guide and Formatter for Swift</a></li>
@@ -967,7 +967,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 4 Feb 2019 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>Relevant Links</h2>
 <ul>
 <li>Key Path Expressions as Functions: https://forums.swift.org/t/key-path-expressions-as-functions/19587</li>
@@ -1032,7 +1032,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 7 Jan 2019 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>Relevant Links</h2>
 <ul>
 <li><a href="https://forums.swift.org/t/new-lsp-language-service-supporting-swift-and-c-family-languages-for-any-editor-and-platform/17024">Announcement Post on Swift Forums</a></li>
@@ -1082,7 +1082,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 3 Dec 2018 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md">Proposal</a></li>
 <li><a href="https://forums.swift.org/t/se-0235-add-result-to-the-standard-library/17752">Forums review phase one</a></li>
@@ -1122,7 +1122,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 5 Nov 2018 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://forums.swift.org/t/opaque-result-types/15645</li>
 <li>LazyMapCollection: https://cocoacasts.com/what-is-a-lazymapcollection-in-swift​</li>
@@ -1165,7 +1165,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 15 Oct 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0200-raw-string-escaping.md">SE-0200 Enhancing String Literals Delimiters to Support Raw Text</a></li>
 <li><a href="https://github.com/twostraws/whats-new-in-swift-5-0">Paul Hudson’s What’s New in Swift 5 Playground</a></li>
@@ -1207,7 +1207,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 20 Aug 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://forums.swift.org/t/plan-for-module-stability/14551</li>
 </ul>
@@ -1244,7 +1244,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 2 Jul 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0213-literal-init-via-coercion.md">SE-0213: Literal initialization via coercion</a></li>
 <li><a href="https://github.com/apple/swift/pull/15311">Implementation (apple/swift#15311)</a></li>
@@ -1281,7 +1281,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 25 Jun 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><code>Never</code> &amp; <code>absurd()</code>: https://twitter.com/pteasima/status/978325590397906944</li>
 <li>Point Free Episode #9 Algebraic Data Types: Exponents – https://www.pointfree.co/episodes/ep9-algebraic-data-types-exponents</li>
@@ -1321,7 +1321,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 18 Jun 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Data Structures and Algorithms in Swift: https://store.raywenderlich.com/products/data-structures-and-algorithms-in-swift</li>
 <li>Swift Algorithm Club: https://github.com/raywenderlich/swift-algorithm-club</li>
@@ -1359,7 +1359,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Wed, 13 Jun 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Ted Kremenek on Twitter: https://twitter.com/tkremenek</li>
 <li>Swift Evolution Dashboard of proposals implemented in Swift 4.2: https://apple.github.io/swift-evolution/#?version=4.2</li>
@@ -1397,7 +1397,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 11 Jun 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>This episode is a little different, where we discuss general announcements from WWDC 2018 not just limited to the Swift language. With special guest Greg Heo.</p>
 <ul>
 <li>Keynote: https://www.apple.com/apple-events/june-2018/</li>
@@ -1443,7 +1443,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 28 May 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Forums:</p>
 <ul>
 <li>https://forums.swift.org/t/pitch-character-and-string-properties/11620</li>
@@ -1489,7 +1489,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 21 May 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>Links</h3>
 <ul>
 <li>Forums: https://forums.swift.org/t/implicit-escaping-of-closures-via-objective-c/12025</li>
@@ -1532,7 +1532,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 14 May 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Blog post on Reimplementation of Implicitly Unwrapped Optionals: https://swift.org/blog/iuo</li>
 <li>SE-0054 Abolish <code>ImplicitlyUnwrappedOptional</code> type: https://github.com/apple/swift-evolution/blob/master/proposals/0054-abolish-iuo.md</li>
@@ -1582,7 +1582,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 7 May 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://github.com/tensorflow/swift/blob/master/docs/DesignOverview.md</li>
 <li>https://twitter.com/chriseidhof/status/989736679417171968</li>
@@ -1630,7 +1630,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 30 Apr 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0206-hashable-enhancements.md</li>
 <li>Swift Evolution review thread &amp; acceptance post: https://forums.swift.org/t/accepted-se-0206-hashable-enhancements/11675/115</li>
@@ -1672,7 +1672,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 23 Apr 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0202-random-unification.md</li>
 <li>Swift Evolution thread: https://forums.swift.org/t/proposal-random-unification/6626</li>
@@ -1715,7 +1715,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 16 Apr 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://github.com/apple/swift-evolution/blob/master/proposals/0197-remove-where.md</li>
 <li>https://github.com/apple/swift-evolution/blob/master/proposals/0203-rename-sequence-elements-equal.md</li>
@@ -1756,7 +1756,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 9 Apr 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://www.tensorflow.org/</li>
 <li>https://youtu.be/Yze693W4MaU</li>
@@ -1794,7 +1794,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 2 Apr 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>We cover two recent Swift Package Manager proposal pitches.</p>
 <ul>
 <li>https://forums.swift.org/t/package-manager-extensible-build-tools/10900</li>
@@ -1832,7 +1832,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 26 Mar 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Conditional conformance: https://swift.org/blog/conditional-conformance/</li>
 <li>Generics manifesto: https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md</li>
@@ -1872,7 +1872,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 19 Mar 2018 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Conditional conformance: https://swift.org/blog/conditional-conformance/</li>
 <li>Generics manifesto: https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md</li>
@@ -1908,7 +1908,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 5 Mar 2018 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>In Today's episode we share thoughts on Dave DeLong's &quot;protocol wishlist&quot; for Swift and other ideas for improving Swift's protocols.</p>
 <ul>
 <li>Blogpost: https://davedelong.com/blog/2018/02/08/swift-protocols-wishlist/</li>
@@ -1941,7 +1941,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 26 Feb 2018 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Announcement on Swift Forums: https://forums.swift.org/t/swift-to-participate-in-gsoc-2018/10147</li>
 <li>Project Ideas: https://swift.org/project-ideas/</li>
@@ -1982,7 +1982,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 19 Feb 2018 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>
 <p>Forum discussion: http://forums.swift.org/t/se-0198-playground-quicklook-api-revamp/9448</p>
@@ -2030,7 +2030,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 12 Feb 2018 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>
 <p>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0189-restrict-cross-module-struct-initializers.md</p>
@@ -2085,7 +2085,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 5 Feb 2018 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><code>Sequence.split</code> should have a Lazy equivalent: <a href="https://bugs.swift.org/browse/SR-6691">SR-6691</a></li>
 <li>Conditional conformance swift.org blog post: https://swift.org/blog/conditional-conformance</li>
@@ -2131,7 +2131,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 29 Jan 2018 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://www.jessesquires.com/blog/swift-weekly-brief-hiatus/</li>
 <li>https://swiftweekly.github.io/issue-101/</li>
@@ -2162,7 +2162,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 22 Jan 2018 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>State of String: ABI, Performance, Ergonomics, and You! https://gist.github.com/milseman/bb39ef7f170641ae52c13600a512782f</li>
 <li>https://twitter.com/Ilseman/status/951181851229483008</li>
@@ -2199,7 +2199,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 15 Jan 2018 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Swift 4.1 will include support for conditional protocol conformance, and we're excited to use it!</p>
 <ul>
 <li>https://swift.org/blog/conditional-conformance/</li>
@@ -2236,7 +2236,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 8 Jan 2018 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Graydon Hoare’s swift-dev email: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20171113/006001.html</li>
 <li>Compiler Performance doc: https://github.com/apple/swift/blob/master/docs/CompilerPerformance.md</li>
@@ -2279,7 +2279,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 18 Dec 2017 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Introduce User-defined &quot;Dynamic Member Lookup&quot; Types:
 <ul>
@@ -2323,7 +2323,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 11 Dec 2017 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://bugs.swift.org/browse/SR-4981</li>
 <li>https://github.com/apple/swift-source-compat-suite/blob/master/projects.json</li>
@@ -2365,7 +2365,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 4 Dec 2017 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Enable core dumps: <code>ulimit -c unlimited</code></li>
 <li>Mutating functions require exclusive access:
@@ -2407,7 +2407,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 27 Nov 2017 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Original proposal: https://github.com/apple/swift-evolution/pull/114</li>
 <li>Latest email: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20171106/040950.html</li>
@@ -2445,7 +2445,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 13 Nov 2017 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Float80 Corrections: https://mobile.twitter.com/daniel_dunbar/status/923694549238611970</li>
 <li>Why the Swift Server Working Group's http library doesn't have an Xcode project: https://mobile.twitter.com/daniel_dunbar/status/923691076635914240</li>
@@ -2492,7 +2492,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 30 Oct 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>JP's FrenchKit talk on &quot;Performance Profiling Swift on Linux&quot;:
 <ul>
@@ -2536,7 +2536,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 23 Oct 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://www.jessesquires.com/blog/floating-point-swift-ulp-and-epsilon/</li>
 <li>https://speakerdeck.com/jessesquires/exploring-swifts-numeric-types-and-protocols</li>
@@ -2587,7 +2587,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 16 Oct 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Server APIs Project: https://swift.org/server-apis/</li>
 <li>Server APIs Working Group: https://swift.org/blog/server-api-workgroup/</li>
@@ -2640,7 +2640,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 9 Oct 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://swift.org/migration-guide-swift4/</li>
 <li>Using two Swift Package Manager manifest files:
@@ -2690,7 +2690,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></description>
       <pubDate>Mon, 2 Oct 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Measuring Swift compile times in Xcode 9: https://www.jessesquires.com/blog/measuring-compile-times-xcode9/</li>
 <li>Profiling your Swift compilation times: http://irace.me/swift-profiling</li>
@@ -2736,7 +2736,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 25 Sep 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Friday Q&amp;A:<br />
 https://mikeash.com/pyblog/friday-qa-2017-09-22-swift-4-weak-references.html</p>
 <p>Leave a review on iTunes:<br />
@@ -2770,7 +2770,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 18 Sep 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>iPhone X keynote + GM seeds for Xcode 9, Swift 4</li>
 <li>Synthesizing Equatable and Hashable: https://github.com/apple/swift-evolution/blob/master/proposals/0185-synthesize-equatable-hashable.md</li>
@@ -2813,7 +2813,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 11 Sep 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Swift.org blog post on Swift Local Refactoring: https://swift.org/blog/swift-local-refactoring/</li>
 <li>Clang-based refactoring engine: http://lists.llvm.org/pipermail/cfe-dev/2017-June/054286.html</li>
@@ -2872,7 +2872,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 4 Sep 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Please take a minute to leave <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203">a review on iTunes</a> and <a href="http://spectrum.chat/specfm/swift-unwrapped">join us on Spectrum chat</a> if you'd like to discuss the show.</p>
 <ul>
 <li>
@@ -2921,7 +2921,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 28 Aug 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Mailing List: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170807/038645.html</li>
 <li>Swift Evolution Readme: https://github.com/apple/swift-evolution/blob/master/README.md</li>
@@ -2952,7 +2952,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 21 Aug 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
 <li>ABI Dashboard: https://swift.org/abi-stability</li>
@@ -2986,7 +2986,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 14 Aug 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Twitter thread on source stability discussion for episode 22: https://twitter.com/swift_unwrapped/status/892023116377075712</li>
 <li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
@@ -3028,7 +3028,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 7 Aug 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
 <li>ABI Dashboard: https://swift.org/abi-stability</li>
@@ -3067,7 +3067,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 31 Jul 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
 <li>ABI Dashboard: https://swift.org/abi-stability</li>
@@ -3099,7 +3099,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 24 Jul 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Bug of the week (sandboxing!): <a href="https://bugs.swift.org/browse/SR-5491">SR-549</a>, <a href="https://bugs.swift.org/browse/SR-5061">SR-5061</a></li>
 <li>String newline escaping: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0182-newline-escape-in-strings.md">SE-0182</a></li>
@@ -3132,7 +3132,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 17 Jul 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Bug of the week: https://bugs.swift.org/browse/SR-4088</li>
 <li>Ted’s email: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20170605/004751.html</li>
@@ -3165,7 +3165,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 10 Jul 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Improvement of the week: https://github.com/apple/swift-package-manager/pull/1249</li>
 <li>Ted’s email: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20170605/004751.html</li>
@@ -3205,7 +3205,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 3 Jul 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>SipHash: https://github.com/lorentey/SipHash</li>
 <li>CryptoSwift: https://github.com/krzyzanowskim/CryptoSwift</li>
@@ -3260,7 +3260,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 26 Jun 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Testing Swift: https://github.com/apple/swift/blob/master/docs/Testing.rst</li>
 <li>Lit: LLVM Integrated Tester: http://llvm.org/docs/CommandGuide/lit.html</li>
@@ -3309,7 +3309,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 19 Jun 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Error Handling: https://github.com/apple/swift/blob/master/docs/ErrorHandling.rst</li>
 <li>Rationale and Proposal: https://github.com/apple/swift/blob/master/docs/ErrorHandlingRationale.rst</li>
@@ -3348,7 +3348,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 12 Jun 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>What should you expect with Swift 4?</h3>
 <p>Some great new features and improvements.</p>
 <ul>
@@ -3395,7 +3395,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 5 Jun 2017 12:52:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>What should you expect with Swift 4?</h3>
 <p>Some great new features and improvements.</p>
 <ul>
@@ -3455,7 +3455,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 29 May 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>SwiftPM iOS
 <ul>
@@ -3513,7 +3513,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 22 May 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Moving to Discourse, email from Ted: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170206/031657.html</li>
 <li>Nate Cook's Discourse experiment: http://discourse.natecook.com/</li>
@@ -3561,7 +3561,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 15 May 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Manifesto: https://github.com/apple/swift/blob/master/docs/OwnershipManifesto.md</li>
 <li>TL;DR: https://gist.github.com/Gankro/1f79fbf2a9776302a9d4c8c0097cc40e</li>
@@ -3623,7 +3623,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 8 May 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h1>SE-0168: Multi-line strings</h1>
 <ul>
 <li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0168-multi-line-string-literals.md</li>
@@ -3690,7 +3690,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 1 May 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>String Manifesto: https://github.com/apple/swift/blob/master/docs/StringManifesto.md</li>
 <li>Chris Lattner on Swift 4 goals including String re-evaluation: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160725/025676.html</li>
@@ -3761,7 +3761,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 24 Apr 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h1>SE-0166: Swift Archival &amp; Serialization</h1>
 <ul>
 <li>NSCoding:
@@ -3837,7 +3837,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 17 Apr 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>Access Control Roller Coaster</h3>
 <ul>
 <li>First came the private/fileprivate change (SE-0025): https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md</li>
@@ -3906,7 +3906,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 10 Apr 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>Swift 3.1 Release</h3>
 <ul>
 <li>Official Swift 3.1 release post: https://swift.org/blog/swift-3-1-released/</li>
@@ -3982,7 +3982,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 3 Apr 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>There's been a much stronger focus on calling ObjC from Swift than the other way around, but in this talk we'll cover both directions and the parts of the Swift language involved in the process.</p>
 <h3>ObjC Interop Overview</h3>
 <ul>
@@ -4052,7 +4052,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 27 Mar 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Swift has evolved since 1.x to have a fluctuating amount of magic/implicit bridging from ObjC and Foundation types, sometimes going in the opposite direction towards very explicit type conversions.</p>
 <p>We've started seeing more of what the &quot;steady state&quot; looks like as Swift 3.x/4.x development matures.</p>
 <p>In the early days, Swift users would need deep compiler internal implementation details to know which NSNumber-representable type could implicitly convert. As of <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0139-bridge-nsnumber-and-nsvalue.md">SE-0139</a> that's a lot clearer.</p>
@@ -4140,7 +4140,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 20 Mar 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Every Swift developer who has migrated code bases from Swift 1.x to 2.x, or even the more tedious 2.x to 3.x knows the pain of migrating to new Swift versions.</p>
 <p>In this episode, we cover:</p>
 <ul>
@@ -4247,7 +4247,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 13 Mar 2017 12:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>In this episode, we dive into the framework we love to hate to love: SourceKit.</p>
 <p>We wrap up with an overview of method dispatch in Swift.</p>
 <h3>SourceKit on Linux</h3>
@@ -4326,7 +4326,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 6 Mar 2017 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>In this episode we take a look at the first full year of open source Swift development and the first complete release cycle (for 3.0) that happened completely in the open. We reflect on where we've been and how we got here. We discuss the initial launch, Swift evolution, the &quot;Great Swift 3 Migration&quot;, and more!</p>
 <ul>
 <li>Open source <a href="https://developer.apple.com/swift/blog/?id=34">announcement</a></li>
@@ -4372,7 +4372,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Fri, 24 Feb 2017 13:00:00 +0000</pubDate>
       <author>shows@spec.fm (Spec)</author>
-      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>There are tons of podcasts out there about general Apple/iOS/macOS development but nothing specifically about only the Swift programming language.</p>
 <p>So, we decided to make a podcast about the Swift language and a commentary on the <a href="https://swiftweekly.github.io/">Swift Weekly Brief</a>. This podcast is a continuation on more details about Swift Weekly and our own thoughts on Swift news.</p>
 <p>If you want to connect with us you can find us and reach out on twitter: <a href="https://twitter.com/simjp">JP Simard</a> &amp; <a href="https://twitter.com/jesse_squires">Jesse Squires</a></p>

--- a/feed.xml
+++ b/feed.xml
@@ -16,15 +16,14 @@
     </image>
     <link>https://swiftunwrapped.github.io</link>
     <itunes:type>episodic</itunes:type>
-    <itunes:summary>An audio spin off of Swift Weekly Brief and discussions on the Swift programming language. </itunes:summary>
+    <itunes:summary>Discussions on the Swift programming language and other projects at Swift.org</itunes:summary>
     <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
     <itunes:explicit>no</itunes:explicit>
     <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
     <itunes:new-feed-url>https://swiftunwrapped.github.io/feed.xml</itunes:new-feed-url>
     <itunes:keywords>Swift, LLVM, LLDB, Clang, Compilers, iOS, macOS, tvOS, watchOS, Technology, Swift Weekly Brief, Swift Package Manager, SPM, Swift Server, Apple, SourceKit, Xcode</itunes:keywords>
     <itunes:owner>
-      <itunes:name>Spec Network, Inc.</itunes:name>
-      <itunes:email>shows@spec.fm</itunes:email>
+      <itunes:name>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:name>
     </itunes:owner>
     <itunes:category text="Technology"/>
     <item>

--- a/feed.xml
+++ b/feed.xml
@@ -3,7 +3,6 @@
   <channel>
     <atom:link href="https://feeds.simplecast.com/3pGv88mm" rel="self" title="MP3 Audio" type="application/atom+xml"/>
     <atom:link href="https://simplecast.superfeedr.com/" rel="hub" xmlns="http://www.w3.org/2005/Atom"/>
-    <generator>https://simplecast.com</generator>
     <title>Swift Unwrapped</title>
     <description>An audio spin off of Swift Weekly Brief and discussions on the Swift programming language. </description>
     <copyright>2020 Spec Network, Inc.</copyright>

--- a/feed.xml
+++ b/feed.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
   <channel>
-    <atom:link href="https://feeds.simplecast.com/3pGv88mm" rel="self" title="MP3 Audio" type="application/atom+xml"/>
-    <atom:link href="https://simplecast.superfeedr.com/" rel="hub" xmlns="http://www.w3.org/2005/Atom"/>
+    <atom:link href="https://swiftunwrapped.github.io/feed.xml" rel="self" type="application/atom+xml" />
+
     <title>Swift Unwrapped</title>
     <description>An audio spin off of Swift Weekly Brief and discussions on the Swift programming language. </description>
     <copyright>2020 Spec Network, Inc.</copyright>

--- a/feed.xml
+++ b/feed.xml
@@ -20,7 +20,7 @@
     <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
     <itunes:explicit>no</itunes:explicit>
     <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
-    <itunes:new-feed-url>https://feeds.simplecast.com/3pGv88mm</itunes:new-feed-url>
+    <itunes:new-feed-url>https://swiftunwrapped.github.io/feed.xml</itunes:new-feed-url>
     <itunes:keywords>Swift, LLVM, LLDB, Clang, Compilers, iOS, macOS, tvOS, watchOS, Technology, Swift Weekly Brief, Swift Package Manager, SPM, Swift Server, Apple, SourceKit, Xcode</itunes:keywords>
     <itunes:owner>
       <itunes:name>Spec Network, Inc.</itunes:name>

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,4398 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <atom:link href="https://feeds.simplecast.com/3pGv88mm" rel="self" title="MP3 Audio" type="application/atom+xml"/>
+    <atom:link href="https://simplecast.superfeedr.com/" rel="hub" xmlns="http://www.w3.org/2005/Atom"/>
+    <generator>https://simplecast.com</generator>
+    <title>Swift Unwrapped</title>
+    <description>An audio spin off of Swift Weekly Brief and discussions on the Swift programming language. </description>
+    <copyright>2020 Spec Network, Inc.</copyright>
+    <language>en</language>
+    <pubDate>Mon, 21 Jun 2021 12:00:00 +0000</pubDate>
+    <lastBuildDate>Mon, 21 Jun 2021 12:00:10 +0000</lastBuildDate>
+    <image>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <title>Swift Unwrapped</title>
+      <url>https://image.simplecastcdn.com/images/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a28195f8-ab73-4040-90cf-6b0ff94bf477/3000x3000/1557116952-artwork.jpg?aid=rss_feed</url>
+    </image>
+    <link>https://spec.fm/podcasts/swift-unwrapped</link>
+    <itunes:type>episodic</itunes:type>
+    <itunes:summary>An audio spin off of Swift Weekly Brief and discussions on the Swift programming language. </itunes:summary>
+    <itunes:author>Spec, JP Simard, Jesse Squires</itunes:author>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:image href="https://image.simplecastcdn.com/images/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a28195f8-ab73-4040-90cf-6b0ff94bf477/3000x3000/1557116952-artwork.jpg?aid=rss_feed"/>
+    <itunes:new-feed-url>https://feeds.simplecast.com/3pGv88mm</itunes:new-feed-url>
+    <itunes:keywords>Swift, LLVM, LLDB, Clang, Compilers, iOS, macOS, tvOS, watchOS, Technology, Swift Weekly Brief, Swift Package Manager, SPM, Swift Server, Apple, SourceKit, Xcode</itunes:keywords>
+    <itunes:owner>
+      <itunes:name>Spec Network, Inc.</itunes:name>
+      <itunes:email>shows@spec.fm</itunes:email>
+    </itunes:owner>
+    <itunes:category text="Technology"/>
+    <item>
+      <guid isPermaLink="false">36d66d6d-3095-445b-a07d-5ca2f1a86638</guid>
+      <title>92: Deinit</title>
+      <description><![CDATA[<ul><li><a href="https://www.hackingwithswift.com/articles/233/whats-new-in-swift-5-5">Paul Hudson's What's New in Swift 5.5</a></li><li><a href="https://swiftbysundell.com/">Swift By Sundell</a></li><li><a href="https://github.com/davedelong/time">Time by Dave DeLong</a> (mistakenly called Chronos during the show)</li></ul>
+]]></description>
+      <pubDate>Mon, 21 Jun 2021 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul><li><a href="https://www.hackingwithswift.com/articles/233/whats-new-in-swift-5-5">Paul Hudson's What's New in Swift 5.5</a></li><li><a href="https://swiftbysundell.com/">Swift By Sundell</a></li><li><a href="https://github.com/davedelong/time">Time by Dave DeLong</a> (mistakenly called Chronos during the show)</li></ul>
+]]></content:encoded>
+      <enclosure length="27800880" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/9415a7c4-e767-4bc1-8438-e67ff03a542c/audio/59932e5c-d516-4f64-9e02-b1923f03261d/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>92: Deinit</itunes:title>
+      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:duration>00:28:57</itunes:duration>
+      <itunes:summary>Jesse and JP talk about Swift 5.5, WWDC 21, how the Swift community has evolved in the 7 years of the language, and wrapping up the show. This is our last episode.
+
+Thanks to all our listeners, guests, sponsors and the Spec network for supporting this show over the last 4 years!</itunes:summary>
+      <itunes:subtitle>Jesse and JP talk about Swift 5.5, WWDC 21, how the Swift community has evolved in the 7 years of the language, and wrapping up the show. This is our last episode.
+
+Thanks to all our listeners, guests, sponsors and the Spec network for supporting this show over the last 4 years!</itunes:subtitle>
+      <itunes:keywords>open source, jp simard, wwdc, swift, jesse squires</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>93</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">60d5a501-8ef4-4434-a4f8-70435083e20a</guid>
+      <title>91: Concurrency, 3 years later</title>
+      <description><![CDATA[<h3>Links</h3><ul><li><a href="https://forums.swift.org/t/swift-concurrency-roadmap/41611">Swift concurrency roadmap</a></li><li><a href="https://swiftunwrapped.github.io/episodes/409cbdc5/">Episode 27: Concurrency with Chris Lattner</a></li><li><a href="https://forums.swift.org/t/concurrency-actors-actor-isolation/41613">[Concurrency] Actors & actor isolation</a></li><li><a href="https://forums.swift.org/t/concurrency-interoperability-with-objective-c/41616">[Concurrency] Interoperability with Objective-C</a></li><li><a href="https://forums.swift.org/t/concurrency-structured-concurrency/41622">[Concurrency] Structured concurrency</a></li><li><a href="https://forums.swift.org/t/concurrency-asynchronous-functions/41619">[Concurrency] Asynchronous functions</a></li><li><a href="https://forums.swift.org/t/concurrency-asyncsequence/42417">[Concurrency] AsyncSequence</a></li><li><a href="https://gist.github.com/DougGregor/444575ac67cbd25bfc4b1d4fd241ae93">Swift Concurrency Proposals Dependencies Graph</a></li><li><a href="https://docs.google.com/document/d/1BEO6QwzcYCUhaGyA-WRoM_phRa7O7mGPNIMdSV4StEE">Protocol-based Actor Isolation: Draft #2</a></li><li><a href="https://forums.swift.org/t/actors-are-reference-types-but-why-classes/42281">Actors are reference types, but why classes?</a></li></ul><h3>Sponsors</h3><ul><li><strong>AWS Amplify</strong> - AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+]]></description>
+      <pubDate>Mon, 7 Dec 2020 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h3>Links</h3><ul><li><a href="https://forums.swift.org/t/swift-concurrency-roadmap/41611">Swift concurrency roadmap</a></li><li><a href="https://swiftunwrapped.github.io/episodes/409cbdc5/">Episode 27: Concurrency with Chris Lattner</a></li><li><a href="https://forums.swift.org/t/concurrency-actors-actor-isolation/41613">[Concurrency] Actors & actor isolation</a></li><li><a href="https://forums.swift.org/t/concurrency-interoperability-with-objective-c/41616">[Concurrency] Interoperability with Objective-C</a></li><li><a href="https://forums.swift.org/t/concurrency-structured-concurrency/41622">[Concurrency] Structured concurrency</a></li><li><a href="https://forums.swift.org/t/concurrency-asynchronous-functions/41619">[Concurrency] Asynchronous functions</a></li><li><a href="https://forums.swift.org/t/concurrency-asyncsequence/42417">[Concurrency] AsyncSequence</a></li><li><a href="https://gist.github.com/DougGregor/444575ac67cbd25bfc4b1d4fd241ae93">Swift Concurrency Proposals Dependencies Graph</a></li><li><a href="https://docs.google.com/document/d/1BEO6QwzcYCUhaGyA-WRoM_phRa7O7mGPNIMdSV4StEE">Protocol-based Actor Isolation: Draft #2</a></li><li><a href="https://forums.swift.org/t/actors-are-reference-types-but-why-classes/42281">Actors are reference types, but why classes?</a></li></ul><h3>Sponsors</h3><ul><li><strong>AWS Amplify</strong> - AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+]]></content:encoded>
+      <enclosure length="43224292" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/0248870d-280f-4df1-8693-c659a1210f4d/audio/1e27b922-a9a5-4678-9203-a539ef1f7b58/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>91: Concurrency, 3 years later</itunes:title>
+      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:duration>00:44:57</itunes:duration>
+      <itunes:summary>Three years after first discussing concurrency in Swift with Chris Lattner, we dive into the latest round of proposals and forum discussions — although this time it is actually happening.</itunes:summary>
+      <itunes:subtitle>Three years after first discussing concurrency in Swift with Chris Lattner, we dive into the latest round of proposals and forum discussions — although this time it is actually happening.</itunes:subtitle>
+      <itunes:keywords>gcd, corelibs-dispatch, programming language, ios, multi-threading, concurrency, low level programming, swift, async, swift 5, threads, programming, tasks, apple, locking, c, actors, await, c++, software, libdispatch</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>92</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">8be517d7-102c-4ffa-bfd6-417f875139f4</guid>
+      <title>90: Swift Atomics</title>
+      <description><![CDATA[<h3>Links</h3><ul><li><a href="https://swift.org/blog/swift-atomics/">Announcement blog post</a></li><li><a href="https://twitter.com/lorentey/">Karoy Lorentey</a></li><li><a href="https://github.com/apple/swift-atomics">GitHub Repository</a></li><li><a href="https://forums.swift.org/c/related-projects/swift-atomics">Atomics forum</a></li><li><a href="https://news.ycombinator.com/item?id=24657500">Hacker News Discussion</a></li><li><a href="https://github.com/glessard/swift-atomics">Guillaume Lessard’s existing swift-atomics repo</a></li></ul><h3>Sponsors</h3><ul><li><strong>AWS Amplify</strong> - AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a>.</p>
+]]></description>
+      <pubDate>Mon, 2 Nov 2020 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h3>Links</h3><ul><li><a href="https://swift.org/blog/swift-atomics/">Announcement blog post</a></li><li><a href="https://twitter.com/lorentey/">Karoy Lorentey</a></li><li><a href="https://github.com/apple/swift-atomics">GitHub Repository</a></li><li><a href="https://forums.swift.org/c/related-projects/swift-atomics">Atomics forum</a></li><li><a href="https://news.ycombinator.com/item?id=24657500">Hacker News Discussion</a></li><li><a href="https://github.com/glessard/swift-atomics">Guillaume Lessard’s existing swift-atomics repo</a></li></ul><h3>Sponsors</h3><ul><li><strong>AWS Amplify</strong> - AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a>.</p>
+]]></content:encoded>
+      <enclosure length="26140572" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/0d6319c6-d943-4a47-9eb0-cd58829472a8/audio/d75cc258-b633-4807-839b-49c17dc299c1/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>90: Swift Atomics</itunes:title>
+      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:duration>00:27:10</itunes:duration>
+      <itunes:summary>Today we talk about the latest Swift open source project, Swift Atomics. The library you shouldn&apos;t use but want to anyway.</itunes:summary>
+      <itunes:subtitle>Today we talk about the latest Swift open source project, Swift Atomics. The library you shouldn&apos;t use but want to anyway.</itunes:subtitle>
+      <itunes:keywords>programming language, ios, multi-threading, concurrency, low level programming, swift, atomics, programming, apple, locking, c, c++, software</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>91</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">f4074287-1a0c-4e34-8f10-25fdcd62a824</guid>
+      <title>89: Implementing the Swift Runtime in Swift, with Jordan Rose</title>
+      <description><![CDATA[<h2>What’s in a Swift runtime?</h2><ul><li><a href="https://belkadan.com/blog/2020/04/Swift-on-Mac-OS-9/">Swift on Mac OS 9</a></li><li><a href="https://belkadan.com/blog/2020/08/Swift-Runtime-Heap-Objects/">Heap Objects</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Type-Layout/">Type Layout</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Type-Metadata/">Type Metadata</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Uniquing-Caches/">Uniquing Caches</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Class-Metadata/">Class Metadata</a></li><li><a href="https://belkadan.com/blog/2020/10/Swift-Runtime-Class-Metadata-Initialization/">Class Metadata Initialization</a></li></ul><h3>Other links</h3><ul><li><a href="https://forums.swift.org/t/guarantee-in-memory-tuple-layout-or-dont/40122">Layout guarantees</a></li><li><a href="https://www.highcaffeinecontent.com/blog/20150124-MPW,-Carbon-and-building-Classic-Mac-OS-apps-in-OS-X">Steve Troughton-Smith’s BitPaint</a></li><li><a href="https://github.com/ksherlock/mpw">@ksherlock’s mpw</a></li><li><a href="https://mikeash.com/pyblog/friday-qa-2017-09-22-swift-4-weak-references.html">An explainer on Swift weak references</a></li></ul><h3>About Jordan</h3><ul><li><a href="https://twitter.com/UINT_MIN">Twitter @UINT_MIN</a></li><li><a href="https://belkadan.com">Belkadan</a></li><li><a href="https://citizensclimatelobby.org">Citizens’ Climate Lobby</a></li></ul><h3> </h3><h3>Sponsors</h3><ul><li><strong>Instabug</strong> - Get Application Performance Monitoring built for mobile apps and stay on top of your app quality with Instabug. Check them out and them them know we sent you at <a href="https://try.instabug.com/SwiftUnwrapped">https://try.instabug.com/SwiftUnwrapped</a></li></ul><p> </p><ul><li><strong>AWS Amplify </strong>- AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3> </h3><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a>.</p>
+]]></description>
+      <pubDate>Mon, 12 Oct 2020 18:10:30 +0000</pubDate>
+      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h2>What’s in a Swift runtime?</h2><ul><li><a href="https://belkadan.com/blog/2020/04/Swift-on-Mac-OS-9/">Swift on Mac OS 9</a></li><li><a href="https://belkadan.com/blog/2020/08/Swift-Runtime-Heap-Objects/">Heap Objects</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Type-Layout/">Type Layout</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Type-Metadata/">Type Metadata</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Uniquing-Caches/">Uniquing Caches</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Class-Metadata/">Class Metadata</a></li><li><a href="https://belkadan.com/blog/2020/10/Swift-Runtime-Class-Metadata-Initialization/">Class Metadata Initialization</a></li></ul><h3>Other links</h3><ul><li><a href="https://forums.swift.org/t/guarantee-in-memory-tuple-layout-or-dont/40122">Layout guarantees</a></li><li><a href="https://www.highcaffeinecontent.com/blog/20150124-MPW,-Carbon-and-building-Classic-Mac-OS-apps-in-OS-X">Steve Troughton-Smith’s BitPaint</a></li><li><a href="https://github.com/ksherlock/mpw">@ksherlock’s mpw</a></li><li><a href="https://mikeash.com/pyblog/friday-qa-2017-09-22-swift-4-weak-references.html">An explainer on Swift weak references</a></li></ul><h3>About Jordan</h3><ul><li><a href="https://twitter.com/UINT_MIN">Twitter @UINT_MIN</a></li><li><a href="https://belkadan.com">Belkadan</a></li><li><a href="https://citizensclimatelobby.org">Citizens’ Climate Lobby</a></li></ul><h3> </h3><h3>Sponsors</h3><ul><li><strong>Instabug</strong> - Get Application Performance Monitoring built for mobile apps and stay on top of your app quality with Instabug. Check them out and them them know we sent you at <a href="https://try.instabug.com/SwiftUnwrapped">https://try.instabug.com/SwiftUnwrapped</a></li></ul><p> </p><ul><li><strong>AWS Amplify </strong>- AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3> </h3><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a>.</p>
+]]></content:encoded>
+      <enclosure length="63787048" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/4eaaf04a-3e8b-4ab7-96ca-84e0f622062f/audio/92563d7e-1b47-4c64-8aa3-e04013fb02f9/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>89: Implementing the Swift Runtime in Swift, with Jordan Rose</itunes:title>
+      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:duration>01:06:22</itunes:duration>
+      <itunes:summary>Today we welcome special guest, Jordan Rose to discuss implementing the Swift runtime in Swift.</itunes:summary>
+      <itunes:subtitle>Today we welcome special guest, Jordan Rose to discuss implementing the Swift runtime in Swift.</itunes:subtitle>
+      <itunes:keywords>runtime, programming language, llvm, ios, heap objects, swift, macos, type layout, compilers, programming, memory layout, apple, class metadata, c, macos 9, xcode, c++, objective-c</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>90</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">2e67f3ee-be16-485f-9f02-10ca1af1d410</guid>
+      <title>88: Swift 5.3</title>
+      <description><![CDATA[<ul><li><a href="https://swift.org/blog/5-3-release-process/">5.3 release process</a></li><li><a href="https://swift.org/blog/additional-linux-distros/">Swift for Linux distros</a></li><li><a href="https://swift.org/blog/aws-lambda-runtime/">AWS lambda Runtime</a></li><li><a href="https://swift.org/blog/swift-service-lifecycle/">Swift Service Lifecycle</a></li><li><a href="https://swift.org/blog/swift-cluster-membership/">Swift Cluster membership</a></li><li><a href="https://apple.github.io/swift-evolution/#?status=accepted&version=5.3">Proposals accepted/implemented in 5.3</a></li><li><a href="https://github.com/apple/swift/commits/release/5.3">Commit history for Swift 5.3 branch</a></li><li><a href="https://github.com/apple/swift/pull/33487">Mike Ash's perf PR</a></li><li><a href="https://www.hackingwithswift.com/articles/218/whats-new-in-swift-5-3">Hacking with Swift What’s New in Swift 5.3</a></li></ul><h2>Get in Touch</h2><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 14 Sep 2020 17:26:37 +0000</pubDate>
+      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul><li><a href="https://swift.org/blog/5-3-release-process/">5.3 release process</a></li><li><a href="https://swift.org/blog/additional-linux-distros/">Swift for Linux distros</a></li><li><a href="https://swift.org/blog/aws-lambda-runtime/">AWS lambda Runtime</a></li><li><a href="https://swift.org/blog/swift-service-lifecycle/">Swift Service Lifecycle</a></li><li><a href="https://swift.org/blog/swift-cluster-membership/">Swift Cluster membership</a></li><li><a href="https://apple.github.io/swift-evolution/#?status=accepted&version=5.3">Proposals accepted/implemented in 5.3</a></li><li><a href="https://github.com/apple/swift/commits/release/5.3">Commit history for Swift 5.3 branch</a></li><li><a href="https://github.com/apple/swift/pull/33487">Mike Ash's perf PR</a></li><li><a href="https://www.hackingwithswift.com/articles/218/whats-new-in-swift-5-3">Hacking with Swift What’s New in Swift 5.3</a></li></ul><h2>Get in Touch</h2><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="17873749" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f66e20f0-f2e0-4aef-953b-3fbf60ea8dc8/88_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>88: Swift 5.3</itunes:title>
+      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:duration>00:18:33</itunes:duration>
+      <itunes:summary>Swift 5.3 will be released very soon. What should we expect?</itunes:summary>
+      <itunes:subtitle>Swift 5.3 will be released very soon. What should we expect?</itunes:subtitle>
+      <itunes:keywords>amazon linux, ubuntu, swift, compilers, programming, swift 5.3, aws, apple, xcode, centos</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>89</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">0f116187-1862-4b2e-90e7-41c11b57b9f7</guid>
+      <title>87: Package Registries and Indexes</title>
+      <description><![CDATA[<ul><li>Swift Package Index<ul><li><a href="https://iosdevweekly.com/issues/460#comment">Intro</a></li><li><a href="https://swiftpackageindex.com">Website</a></li><li><a href="https://forums.swift.org/t/introducing-the-swift-package-index/37512">Forum</a></li><li><a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server">GitHub</a></li><li><a href="https://github.com/SwiftPackageIndex/PackageList">Package List</a></li><li><a href="https://twitter.com/daveverwer">Dave</a></li><li><a href="https://twitter.com/_sa_s">Sven</a></li><li><a href="https://cocoapods.org">CocoaPods website</a></li></ul></li><li>Swift Package Registry<ul><li><a href="https://forums.swift.org/t/swift-package-registry-service/37219">Swift Package Registry Service Pitch</a><ul><li><a href="https://twitter.com/mattt/status/1278706413921951746">Tweet</a></li></ul></li><li><a href="https://forums.swift.org/t/package-manager-source-archive-dependencies/38626">Package Manager Source Archive Dependencies Pitch</a><ul><li><a href="https://twitter.com/mattt/status/1285966688597315584">Tweet</a></li></ul></li><li><a href="https://twitter.com/mattt">Mattt Thompson</a></li></ul></li></ul><h2>Get in Touch</h2><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 3 Aug 2020 12:00:06 +0000</pubDate>
+      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul><li>Swift Package Index<ul><li><a href="https://iosdevweekly.com/issues/460#comment">Intro</a></li><li><a href="https://swiftpackageindex.com">Website</a></li><li><a href="https://forums.swift.org/t/introducing-the-swift-package-index/37512">Forum</a></li><li><a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server">GitHub</a></li><li><a href="https://github.com/SwiftPackageIndex/PackageList">Package List</a></li><li><a href="https://twitter.com/daveverwer">Dave</a></li><li><a href="https://twitter.com/_sa_s">Sven</a></li><li><a href="https://cocoapods.org">CocoaPods website</a></li></ul></li><li>Swift Package Registry<ul><li><a href="https://forums.swift.org/t/swift-package-registry-service/37219">Swift Package Registry Service Pitch</a><ul><li><a href="https://twitter.com/mattt/status/1278706413921951746">Tweet</a></li></ul></li><li><a href="https://forums.swift.org/t/package-manager-source-archive-dependencies/38626">Package Manager Source Archive Dependencies Pitch</a><ul><li><a href="https://twitter.com/mattt/status/1285966688597315584">Tweet</a></li></ul></li><li><a href="https://twitter.com/mattt">Mattt Thompson</a></li></ul></li></ul><h2>Get in Touch</h2><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="34345134" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b6787f56-3a6d-43cb-884e-820a1028bba1/87_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>87: Package Registries and Indexes</itunes:title>
+      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/2715067c-341c-4704-8ff3-ab5f74ee1281/f53f606d-6e7e-480f-b270-9599a36aeb16/3000x3000/swift-unwrapped-art.jpg?aid=rss_feed"/>
+      <itunes:duration>00:35:42</itunes:duration>
+      <itunes:summary>There&apos;s a lot happening recently in the world of package managers, registries and indexes. Let&apos;s unwrap that.</itunes:summary>
+      <itunes:subtitle>There&apos;s a lot happening recently in the world of package managers, registries and indexes. Let&apos;s unwrap that.</itunes:subtitle>
+      <itunes:keywords>libraries, registries, programming language, swift, open source, package manager, swift evolution, programming, github, apple, compiler, swift package manager, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>88</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">fb840a2b-91ec-45d5-8f0f-2fcb3e3fd1b6</guid>
+      <title>86: Tuples</title>
+      <description><![CDATA[<h4>SE-0282 Tuples conform to Equatable, Comparable, and Hashable</h4><ul><li>Acceptance: <a href="https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658">https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658</a></li><li>Review: <a href="https://forums.swift.org/t/se-0283-tuples-conform-to-equatable-comparable-and-hashable/36140">https://forums.swift.org/t/se-0283-tuples-conform-to-equatable-comparable-and-hashable/36140</a></li><li>Proposal: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0283-tuples-are-equatable-comparable-hashable.md">https://github.com/apple/swift-evolution/blob/master/proposals/0283-tuples-are-equatable-comparable-hashable.md</a></li></ul><p>Bow: <a href="https://bow-swift.io">https://bow-swift.io</a></p><h3>👋 Get in Touch</h3><p>We are <a href="https://twitter.com/swift_unwrapped">@swift_unwrapped</a> on twitter. Follow us, ask us a question, let us know what you think of the show! If you want to follow us individually, we're <a href="https://twitter.com/jesse_squires">@jesse_squires</a> and <a href="https://twitter.com/simjp">@simjp</a>.</p><h3>🖤 Leave A Review</h3><p>If you're enjoying the show. The best and easiest way to show your support is by heading over to iTunes and leaving us a review! Not only do you let us know what you like about the show, but you're also helping other Swift language folks find the show.</p><p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
+]]></description>
+      <pubDate>Thu, 18 Jun 2020 12:00:04 +0000</pubDate>
+      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h4>SE-0282 Tuples conform to Equatable, Comparable, and Hashable</h4><ul><li>Acceptance: <a href="https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658">https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658</a></li><li>Review: <a href="https://forums.swift.org/t/se-0283-tuples-conform-to-equatable-comparable-and-hashable/36140">https://forums.swift.org/t/se-0283-tuples-conform-to-equatable-comparable-and-hashable/36140</a></li><li>Proposal: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0283-tuples-are-equatable-comparable-hashable.md">https://github.com/apple/swift-evolution/blob/master/proposals/0283-tuples-are-equatable-comparable-hashable.md</a></li></ul><p>Bow: <a href="https://bow-swift.io">https://bow-swift.io</a></p><h3>👋 Get in Touch</h3><p>We are <a href="https://twitter.com/swift_unwrapped">@swift_unwrapped</a> on twitter. Follow us, ask us a question, let us know what you think of the show! If you want to follow us individually, we're <a href="https://twitter.com/jesse_squires">@jesse_squires</a> and <a href="https://twitter.com/simjp">@simjp</a>.</p><h3>🖤 Leave A Review</h3><p>If you're enjoying the show. The best and easiest way to show your support is by heading over to iTunes and leaving us a review! Not only do you let us know what you like about the show, but you're also helping other Swift language folks find the show.</p><p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
+]]></content:encoded>
+      <enclosure length="38973156" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/641073f1-f00c-4303-b83d-140a78ceab87/project-86v2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>86: Tuples</itunes:title>
+      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/2715067c-341c-4704-8ff3-ab5f74ee1281/2fa51834-b88e-4197-a2ad-025dc36e4a30/3000x3000/swift-unwrapped-art.jpg?aid=rss_feed"/>
+      <itunes:duration>00:40:32</itunes:duration>
+      <itunes:summary>Is it pronounced &quot;Tuple&quot; or &quot;Tuple&quot;?</itunes:summary>
+      <itunes:subtitle>Is it pronounced &quot;Tuple&quot; or &quot;Tuple&quot;?</itunes:subtitle>
+      <itunes:keywords>comparable, ios, swift, tuple, macos, open source, swift evolution, programming, equatable, apple, compiler, hashable, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>87</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">3c8ad665-6bf9-4610-b1f6-5c61aee3e7e2</guid>
+      <title>85: Swift on Windows and other news</title>
+      <description><![CDATA[<ul>
+<li>Foundation on Windows: https://forums.swift.org/t/swift-soars-ever-higher/34036</li>
+<li>Interoperability between Swift and C++: https://forums.swift.org/t/manifesto-interoperability-between-swift-and-c/33874</li>
+<li>Swift playgrounds for mac: https://apps.apple.com/us/app/swift-playgrounds/id1496833156?mt=12</li>
+<li>Swift crypto: https://swift.org/blog/crypto/</li>
+<li>Standard Library Preview Package: https://swift.org/blog/preview-package/</li>
+<li>Update on SE-0110 and SE-0155: https://forums.swift.org/t/update-on-se-0110-and-se-0155/33948</li>
+</ul>
+<h2>🙏 Thanks to today's sponsor: <a href="https://www.youtube.com/squaredev">Square</a></h2>
+<p>Check out the tutorial for Square’s In-App Payments SDK for iOS on their new developer YouTube channel:  <a href="https://www.youtube.com/squaredev">youtube.com/squaredev</a></p>
+<h2>👋 Get in Touch</h2>
+<p>We are <a href="https://twitter.com/swift_unwrapped">@swift_unwrapped</a> on twitter. Follow us, ask us a question, let us know what you think of the show! If you want to follow us individually, we're <a href="https://twitter.com/jesse_squires">@jesse_squires</a> and <a href="https://twitter.com/simjp">@simjp</a>.</p>
+<h2>🖤 Leave A Review</h2>
+<p>If you're enjoying the show. The best and easiest way to show your support is by heading over to iTunes and leaving us a review! Not only do you let us know what you like about the show, but you're also helping other Swift language folks find the show.</p>
+<p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
+]]></description>
+      <pubDate>Tue, 3 Mar 2020 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Foundation on Windows: https://forums.swift.org/t/swift-soars-ever-higher/34036</li>
+<li>Interoperability between Swift and C++: https://forums.swift.org/t/manifesto-interoperability-between-swift-and-c/33874</li>
+<li>Swift playgrounds for mac: https://apps.apple.com/us/app/swift-playgrounds/id1496833156?mt=12</li>
+<li>Swift crypto: https://swift.org/blog/crypto/</li>
+<li>Standard Library Preview Package: https://swift.org/blog/preview-package/</li>
+<li>Update on SE-0110 and SE-0155: https://forums.swift.org/t/update-on-se-0110-and-se-0155/33948</li>
+</ul>
+<h2>🙏 Thanks to today's sponsor: <a href="https://www.youtube.com/squaredev">Square</a></h2>
+<p>Check out the tutorial for Square’s In-App Payments SDK for iOS on their new developer YouTube channel:  <a href="https://www.youtube.com/squaredev">youtube.com/squaredev</a></p>
+<h2>👋 Get in Touch</h2>
+<p>We are <a href="https://twitter.com/swift_unwrapped">@swift_unwrapped</a> on twitter. Follow us, ask us a question, let us know what you think of the show! If you want to follow us individually, we're <a href="https://twitter.com/jesse_squires">@jesse_squires</a> and <a href="https://twitter.com/simjp">@simjp</a>.</p>
+<h2>🖤 Leave A Review</h2>
+<p>If you're enjoying the show. The best and easiest way to show your support is by heading over to iTunes and leaving us a review! Not only do you let us know what you like about the show, but you're also helping other Swift language folks find the show.</p>
+<p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
+]]></content:encoded>
+      <enclosure length="12276069" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8f254c9e-ffbc-438c-850e-2c09480eb5a5/85-swiftonwindowsv2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>85: Swift on Windows and other news</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8f254c9e-ffbc-438c-850e-2c09480eb5a5/3000x3000/1583089818-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:25:26</itunes:duration>
+      <itunes:summary>Swift Foundation is now building on Windows and passing all tests, interop with C++ is being discussed on the forums, and new Swift libraries are available.</itunes:summary>
+      <itunes:subtitle>Swift Foundation is now building on Windows and passing all tests, interop with C++ is being discussed on the forums, and new Swift libraries are available.</itunes:subtitle>
+      <itunes:keywords>compiler, standard library preview package, swift, open source, programming, windows, crypto, xcode, c++, playgrounds, apple</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>86</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">63512e03-26e7-424f-a069-f49b87a08071</guid>
+      <title>84: Swift World Tour 2020</title>
+      <description><![CDATA[<ul>
+<li>Magic file names: https://github.com/apple/swift-evolution/blob/master/proposals/0274-magic-file.md</li>
+<li>Multi-pattern catch clauses
+<ul>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0276-multi-pattern-catch-clauses.md</li>
+<li>https://forums.swift.org/t/se-0276-multi-pattern-catch-clauses/32620</li>
+</ul>
+</li>
+<li>Road to Swift 6: https://forums.swift.org/t/on-the-road-to-swift-6/32862</li>
+</ul>
+<h2>👋 Get in Touch</h2>
+<p>We are <a href="https://twitter.com/swift_unwrapped">@swift_unwrapped</a> on twitter. Follow us, ask us a question, let us know what you think of the show! If you want to follow us individually, we're <a href="https://twitter.com/jesse_squires">@jesse_squires</a> and <a href="https://twitter.com/simjp">@simjp</a>.</p>
+<h2>🖤 Leave A Review</h2>
+<p>If you're enjoying the show. The best and easiest way to show your support is by heading over to iTunes and leaving us a review! Not only do you let us know what you like about the show, but you're also helping other Swift language folks find the show.</p>
+<p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
+]]></description>
+      <pubDate>Mon, 3 Feb 2020 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Magic file names: https://github.com/apple/swift-evolution/blob/master/proposals/0274-magic-file.md</li>
+<li>Multi-pattern catch clauses
+<ul>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0276-multi-pattern-catch-clauses.md</li>
+<li>https://forums.swift.org/t/se-0276-multi-pattern-catch-clauses/32620</li>
+</ul>
+</li>
+<li>Road to Swift 6: https://forums.swift.org/t/on-the-road-to-swift-6/32862</li>
+</ul>
+<h2>👋 Get in Touch</h2>
+<p>We are <a href="https://twitter.com/swift_unwrapped">@swift_unwrapped</a> on twitter. Follow us, ask us a question, let us know what you think of the show! If you want to follow us individually, we're <a href="https://twitter.com/jesse_squires">@jesse_squires</a> and <a href="https://twitter.com/simjp">@simjp</a>.</p>
+<h2>🖤 Leave A Review</h2>
+<p>If you're enjoying the show. The best and easiest way to show your support is by heading over to iTunes and leaving us a review! Not only do you let us know what you like about the show, but you're also helping other Swift language folks find the show.</p>
+<p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
+]]></content:encoded>
+      <enclosure length="31512580" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/34c97512-6201-477a-a478-b74d6ac2a7fd/84-swiftworldtour_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>84: Swift World Tour 2020</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/34c97512-6201-477a-a478-b74d6ac2a7fd/3000x3000/1580427888-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:32:45</itunes:duration>
+      <itunes:summary>We discuss recent news, evolution proposals, and Swift 6</itunes:summary>
+      <itunes:subtitle>We discuss recent news, evolution proposals, and Swift 6</itunes:subtitle>
+      <itunes:keywords>compiler, apple, swift, open source, programming, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>85</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">dcc2c8b1-df8d-4eab-890e-40a3b49bbce4</guid>
+      <title>83: Modify Accessors</title>
+      <description><![CDATA[<ul>
+<li><a href="https://forums.swift.org/t/modify-accessors/31872">Forum post</a></li>
+<li><a href="https://www.youtube.com/watch?v=BXJIIQ-B4-E">Functional Swift conference talk</a></li>
+<li><a href="https://forums.swift.org/t/modify-accessors/31872/27">Coroutine explanation by John McCall</a></li>
+</ul>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 6 Jan 2020 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li><a href="https://forums.swift.org/t/modify-accessors/31872">Forum post</a></li>
+<li><a href="https://www.youtube.com/watch?v=BXJIIQ-B4-E">Functional Swift conference talk</a></li>
+<li><a href="https://forums.swift.org/t/modify-accessors/31872/27">Coroutine explanation by John McCall</a></li>
+</ul>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="30742914" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/94ee22bc-9244-4aea-9145-d1b776f3888e/83-modifyaccessors_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>83: Modify Accessors</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/94ee22bc-9244-4aea-9145-d1b776f3888e/3000x3000/1578113303-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:31:54</itunes:duration>
+      <itunes:summary>We discuss a recent Swift Evolution pitch from Ben Cohen on Modify Accessors.</itunes:summary>
+      <itunes:subtitle>We discuss a recent Swift Evolution pitch from Ben Cohen on Modify Accessors.</itunes:subtitle>
+      <itunes:keywords>apple, swift, open source, properties, compiler, programming, accessors, xcode, modify, yield</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>84</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">10ec0f1b-d23c-429e-b103-c451d2a91e47</guid>
+      <title>82: Swift&apos;s New Diagnostic Architecture</title>
+      <description><![CDATA[<p>The way Swift reports compilation diagnostics like errors, warnings and fixits is about to improve in Swift 5.2.</p>
+<ul>
+<li><a href="https://swift.org/blog/new-diagnostic-arch-overview/">Blog post</a></li>
+<li><a href="https://forums.swift.org/t/swift-org-blog-new-diagnostic-architecture-overview/29905">Forum discussion</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://vettery.com/swiftunwrapped">Vettery</a></h3>
+<p>Vettery is an online hiring marketplace that's changing the way people hire and get hired. Make a free profile, name your salary, and connect with hiring managers from top employers today.</p>
+<p>Listeners of Swift Unwrapped can sign up on <a href="https://vettery.com/swiftunwrapped">vettery.com/swiftunwrapped</a> and get a $300 bonus if they accept a job through Vettery.</p>
+<h3><a href="https://youtube.com/squaredev">Square</a></h3>
+<p>Check out the new <a href="https://youtube.com/squaredev">Square YouTube channel for developers</a>. Square has SDKs and APIs to make payments and run a business.</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 2 Dec 2019 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>The way Swift reports compilation diagnostics like errors, warnings and fixits is about to improve in Swift 5.2.</p>
+<ul>
+<li><a href="https://swift.org/blog/new-diagnostic-arch-overview/">Blog post</a></li>
+<li><a href="https://forums.swift.org/t/swift-org-blog-new-diagnostic-architecture-overview/29905">Forum discussion</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://vettery.com/swiftunwrapped">Vettery</a></h3>
+<p>Vettery is an online hiring marketplace that's changing the way people hire and get hired. Make a free profile, name your salary, and connect with hiring managers from top employers today.</p>
+<p>Listeners of Swift Unwrapped can sign up on <a href="https://vettery.com/swiftunwrapped">vettery.com/swiftunwrapped</a> and get a $300 bonus if they accept a job through Vettery.</p>
+<h3><a href="https://youtube.com/squaredev">Square</a></h3>
+<p>Check out the new <a href="https://youtube.com/squaredev">Square YouTube channel for developers</a>. Square has SDKs and APIs to make payments and run a business.</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="34621040" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/2c2ea7b8-9cd0-45ff-bae2-966977d4ab74/82_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>82: Swift&apos;s New Diagnostic Architecture</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/2c2ea7b8-9cd0-45ff-bae2-966977d4ab74/3000x3000/1575173492-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:36:00</itunes:duration>
+      <itunes:summary>The way Swift reports compilation diagnostics like errors, warnings and fixits is about to improve in Swift 5.2.</itunes:summary>
+      <itunes:subtitle>The way Swift reports compilation diagnostics like errors, warnings and fixits is about to improve in Swift 5.2.</itunes:subtitle>
+      <itunes:keywords>swift, open source, apple, errors, vettery, programming, compiler, fixits, warnings, xcode, square, diagnostics</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>83</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">c7cb38b8-a281-414f-b4eb-867b5b7fda32</guid>
+      <title>81: Swift Compiler Driver</title>
+      <description><![CDATA[<p>Would you like some Swift in your Swift? The compiler driver is getting a shiny new implementation in Swift and there's no shortage of opportunities to contribute.</p>
+<ul>
+<li><a href="https://forums.swift.org/t/new-project-announcement-swift-compiler-driver-reimplementation-in-swift/29696">Forum discussion</a></li>
+<li><a href="https://github.com/apple/swift-driver">Project on GitHub</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h3><a href="https://vettery.com/swiftunwrapped">Vettery</a></h3>
+<p>Vettery is an online hiring marketplace that's changing the way people hire and get hired. Make a free profile, name your salary, and connect with hiring managers from top employers today.</p>
+<p>Listeners of Swift Unwrapped can sign up on <a href="https://vettery.com/swiftunwrapped">vettery.com/swiftunwrapped</a> and get a $300 bonus if they accept a job through Vettery.</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 4 Nov 2019 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>Would you like some Swift in your Swift? The compiler driver is getting a shiny new implementation in Swift and there's no shortage of opportunities to contribute.</p>
+<ul>
+<li><a href="https://forums.swift.org/t/new-project-announcement-swift-compiler-driver-reimplementation-in-swift/29696">Forum discussion</a></li>
+<li><a href="https://github.com/apple/swift-driver">Project on GitHub</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h3><a href="https://vettery.com/swiftunwrapped">Vettery</a></h3>
+<p>Vettery is an online hiring marketplace that's changing the way people hire and get hired. Make a free profile, name your salary, and connect with hiring managers from top employers today.</p>
+<p>Listeners of Swift Unwrapped can sign up on <a href="https://vettery.com/swiftunwrapped">vettery.com/swiftunwrapped</a> and get a $300 bonus if they accept a job through Vettery.</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="25413788" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5136fbe5-9c97-4779-a22b-6fe5b2961229/81_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>81: Swift Compiler Driver</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5136fbe5-9c97-4779-a22b-6fe5b2961229/3000x3000/1572712328-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:26:24</itunes:duration>
+      <itunes:summary>Would you like some Swift in your Swift? The compiler driver is getting a shiny new implementation in Swift and there&apos;s no shortage of opportunities to contribute.</itunes:summary>
+      <itunes:subtitle>Would you like some Swift in your Swift? The compiler driver is getting a shiny new implementation in Swift and there&apos;s no shortage of opportunities to contribute.</itunes:subtitle>
+      <itunes:keywords>compiler, swift, open source, swift evolution, c++, apple, self hosting language, programming, programming language, clubhouse, xcode, vettery</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>82</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">e1e214a5-1f5d-4133-85aa-bc3d37053b7d</guid>
+      <title>80: Standard Library Preview Package</title>
+      <description><![CDATA[<p>The Swift of tomorrow... today! The Standard Library Preview Package would allow you to try out upcoming Swift features before they officially ship with new language versions.</p>
+<ul>
+<li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0264-stdlib-preview-package.md</li>
+<li>Forum: https://forums.swift.org/t/pitch-standard-library-preview-package/27202</li>
+<li>Babeljs: https://babeljs.io</li>
+<li>SE-0220: https://github.com/apple/swift-evolution/blob/master/proposals/0220-count-where.md</li>
+<li>How to Read the Swift Standard Library Source: https://oleb.net/blog/2016/10/swift-stdlib-source/</li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 7 Oct 2019 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>The Swift of tomorrow... today! The Standard Library Preview Package would allow you to try out upcoming Swift features before they officially ship with new language versions.</p>
+<ul>
+<li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0264-stdlib-preview-package.md</li>
+<li>Forum: https://forums.swift.org/t/pitch-standard-library-preview-package/27202</li>
+<li>Babeljs: https://babeljs.io</li>
+<li>SE-0220: https://github.com/apple/swift-evolution/blob/master/proposals/0220-count-where.md</li>
+<li>How to Read the Swift Standard Library Source: https://oleb.net/blog/2016/10/swift-stdlib-source/</li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="28708165" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/9e3c7017-37a3-4f34-9f94-c4cbccc1871c/80_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>80: Standard Library Preview Package</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/9e3c7017-37a3-4f34-9f94-c4cbccc1871c/3000x3000/1570295313-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:29:50</itunes:duration>
+      <itunes:summary>The Swift of tomorrow... today! The Standard Library Preview Package would allow you to try out upcoming Swift features before they officially ship with new language versions.</itunes:summary>
+      <itunes:subtitle>The Swift of tomorrow... today! The Standard Library Preview Package would allow you to try out upcoming Swift features before they officially ship with new language versions.</itunes:subtitle>
+      <itunes:keywords>programming language, apple, swift, open source, clubhouse, babeljs, programming, swift evolution, compiler, objective-c, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>81</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">301878ce-de61-452d-bc49-9e3e883cea46</guid>
+      <title>79: Swift 5.1 with Doug Gregor</title>
+      <description><![CDATA[<ul>
+<li>Burritos: https://github.com/guillermomuntaner/Burritos</li>
+<li>SE-0260 Library Evolution: https://github.com/apple/swift-evolution/blob/master/proposals/0260-library-evolution.md</li>
+<li>SE-0030 Property Behaviors: https://github.com/apple/swift-evolution/blob/master/proposals/0030-property-behavior-decls.md</li>
+<li>SE-0258 Property Wrappers: https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md</li>
+<li>Function Builders: https://forums.swift.org/t/function-builders/25167</li>
+<li>SE-0244 Opaque Result Types: https://github.com/apple/swift-evolution/blob/master/proposals/0244-opaque-result-types.md</li>
+<li>SE-0255 Implicit returns from single-expression functions: https://github.com/apple/swift-evolution/blob/master/proposals/0255-omit-return.md</li>
+<li>SwiftUI: https://developer.apple.com/xcode/swiftui/</li>
+</ul>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 16 Sep 2019 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Burritos: https://github.com/guillermomuntaner/Burritos</li>
+<li>SE-0260 Library Evolution: https://github.com/apple/swift-evolution/blob/master/proposals/0260-library-evolution.md</li>
+<li>SE-0030 Property Behaviors: https://github.com/apple/swift-evolution/blob/master/proposals/0030-property-behavior-decls.md</li>
+<li>SE-0258 Property Wrappers: https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md</li>
+<li>Function Builders: https://forums.swift.org/t/function-builders/25167</li>
+<li>SE-0244 Opaque Result Types: https://github.com/apple/swift-evolution/blob/master/proposals/0244-opaque-result-types.md</li>
+<li>SE-0255 Implicit returns from single-expression functions: https://github.com/apple/swift-evolution/blob/master/proposals/0255-omit-return.md</li>
+<li>SwiftUI: https://developer.apple.com/xcode/swiftui/</li>
+</ul>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="50234723" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e4296fcf-b739-4226-9cdd-1cdaf34bae5c/79_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>79: Swift 5.1 with Doug Gregor</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e4296fcf-b739-4226-9cdd-1cdaf34bae5c/3000x3000/1568513968-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:52:16</itunes:duration>
+      <itunes:summary>We invite special guest, Doug Gregor, back to the show to discuss all things Swift 5.1</itunes:summary>
+      <itunes:subtitle>We invite special guest, Doug Gregor, back to the show to discuss all things Swift 5.1</itunes:subtitle>
+      <itunes:keywords>objective-c, property wrappers, swift, open source, module stability, opaque result types, programming language, property behaviors, programming, apple, library evolution, function builders, xcode, compiler, swiftui, swift evolution</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>80</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">e9a446e3-6ebc-425d-8060-9fd43a921791</guid>
+      <title>78: Binary Dependencies in Swift Package Manager</title>
+      <description><![CDATA[<ul>
+<li>Forum pitch: https://forums.swift.org/t/pitch-support-for-binary-dependencies/27620</li>
+<li>Swift ABI Stability: https://swift.org/blog/abi-stability-and-more/</li>
+<li>Library Evolution for Stable ABIs: https://github.com/apple/swift-evolution/blob/master/proposals/0260-library-evolution.md</li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 2 Sep 2019 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Forum pitch: https://forums.swift.org/t/pitch-support-for-binary-dependencies/27620</li>
+<li>Swift ABI Stability: https://swift.org/blog/abi-stability-and-more/</li>
+<li>Library Evolution for Stable ABIs: https://github.com/apple/swift-evolution/blob/master/proposals/0260-library-evolution.md</li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="28831488" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e3a1605d-aa61-483c-b135-dd39c75bc077/78_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>78: Binary Dependencies in Swift Package Manager</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e3a1605d-aa61-483c-b135-dd39c75bc077/3000x3000/1567297343-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:29:58</itunes:duration>
+      <itunes:summary>What&apos;s one feature missing from the Swift Package Manager that CocoaPods has had for years? Binary dependencies! But how would this work in SPM?</itunes:summary>
+      <itunes:subtitle>What&apos;s one feature missing from the Swift Package Manager that CocoaPods has had for years? Binary dependencies! But how would this work in SPM?</itunes:subtitle>
+      <itunes:keywords>compiler, carthage, swift, apple, open source, spm, objective-c, cocoapods, programming, programming language, swift evolution, swift package manager, xcode, clubhouse</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>79</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">2a1b7fed-d144-430c-925f-3bb31b8105e1</guid>
+      <title>77: Generic Math Functions and Approximate Equality</title>
+      <description><![CDATA[<ul>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0246-mathable.md">Proposal SE-0246</a></li>
+<li><a href="https://speakerdeck.com/jessesquires/exploring-swifts-numeric-types-and-protocols">Exploring Swift's Numeric Types and Protocols</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0259-approximately-equal.md">Proposal SE-0259</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0233-additive-arithmetic-protocol.md">Proposal SE-0233</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h3><a href="https://instabug.com/swift?utm_source=swift&amp;utm_medium=podcasts&amp;utm_campaign=swiftunwrapped-podcasts-q319-July">Instabug</a></h3>
+<p>Squash bugs in less than a minute with Instabug. Get a <a href="https://instabug.com/swift?utm_source=swift&amp;utm_medium=podcasts&amp;utm_campaign=swiftunwrapped-podcasts-q319-July">14-days trial and their brand new t-shirt</a> once you signup and integrate Instabug in your app.</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 5 Aug 2019 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0246-mathable.md">Proposal SE-0246</a></li>
+<li><a href="https://speakerdeck.com/jessesquires/exploring-swifts-numeric-types-and-protocols">Exploring Swift's Numeric Types and Protocols</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0259-approximately-equal.md">Proposal SE-0259</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0233-additive-arithmetic-protocol.md">Proposal SE-0233</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h3><a href="https://instabug.com/swift?utm_source=swift&amp;utm_medium=podcasts&amp;utm_campaign=swiftunwrapped-podcasts-q319-July">Instabug</a></h3>
+<p>Squash bugs in less than a minute with Instabug. Get a <a href="https://instabug.com/swift?utm_source=swift&amp;utm_medium=podcasts&amp;utm_campaign=swiftunwrapped-podcasts-q319-July">14-days trial and their brand new t-shirt</a> once you signup and integrate Instabug in your app.</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="24446216" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a6992481-1ec7-4d05-a4d2-1d57cd6f520a/77_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>77: Generic Math Functions and Approximate Equality</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a6992481-1ec7-4d05-a4d2-1d57cd6f520a/3000x3000/1564796280-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:25:24</itunes:duration>
+      <itunes:summary>We discuss the new generic math functions coming to Swift, as well as approximate equality for floating point numbers.</itunes:summary>
+      <itunes:subtitle>We discuss the new generic math functions coming to Swift, as well as approximate equality for floating point numbers.</itunes:subtitle>
+      <itunes:keywords>programming language, apple, clubhouse, swift, open source, swift evolution, programming, instabug, compiler, xcode, math, delegates</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>78</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">54c45604-4cb2-48d5-b99f-34762efb0a3a</guid>
+      <title>76: Property Wrappers</title>
+      <description><![CDATA[<ul>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md">Proposal SE-0258</a></li>
+<li>Review threads:
+<ul>
+<li><a href="https://forums.swift.org/t/se-0258-property-delegates/23139">First review</a></li>
+<li><a href="https://forums.swift.org/t/se-0258-property-wrappers-second-review/25843">Second review</a></li>
+<li><a href="https://forums.swift.org/t/se-0258-property-wrappers-third-review/26399">Third review</a></li>
+</ul>
+</li>
+<li>Blog post by <a href="https://twitter.com/v_pradeilles">Vincent Padreilles</a> on <a href="https://gist.github.com/vincent-pradeilles/875c9dd165542912f3803f8e01b3e15e">using property wrappers</a></li>
+<li>Blog post by <a href="https://twitter.com/johnsundell">John Sundell</a> on <a href="https://www.swiftbysundell.com/posts/the-swift-51-features-that-power-swiftuis-api#property-wrappers">The Swift 5.1 features that power SwiftUI’s API</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0030-property-behavior-decls.md">Originally pitched in the Swift forums as &quot;Property Behaviors&quot; in 2015-2016</a></li>
+<li><a href="https://nshipster.com/propertywrapper/">NSHipster article</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h3><a href="https://instabug.com/swift?utm_source=swift&amp;utm_medium=podcasts&amp;utm_campaign=swiftunwrapped-podcasts-q319-July">Instabug</a></h3>
+<p>Squash bugs in less than a minute with Instabug. Get a <a href="https://instabug.com/swift?utm_source=swift&amp;utm_medium=podcasts&amp;utm_campaign=swiftunwrapped-podcasts-q319-July">14-days trial and their brand new t-shirt</a> once you signup and integrate Instabug in your app.</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 1 Jul 2019 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md">Proposal SE-0258</a></li>
+<li>Review threads:
+<ul>
+<li><a href="https://forums.swift.org/t/se-0258-property-delegates/23139">First review</a></li>
+<li><a href="https://forums.swift.org/t/se-0258-property-wrappers-second-review/25843">Second review</a></li>
+<li><a href="https://forums.swift.org/t/se-0258-property-wrappers-third-review/26399">Third review</a></li>
+</ul>
+</li>
+<li>Blog post by <a href="https://twitter.com/v_pradeilles">Vincent Padreilles</a> on <a href="https://gist.github.com/vincent-pradeilles/875c9dd165542912f3803f8e01b3e15e">using property wrappers</a></li>
+<li>Blog post by <a href="https://twitter.com/johnsundell">John Sundell</a> on <a href="https://www.swiftbysundell.com/posts/the-swift-51-features-that-power-swiftuis-api#property-wrappers">The Swift 5.1 features that power SwiftUI’s API</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0030-property-behavior-decls.md">Originally pitched in the Swift forums as &quot;Property Behaviors&quot; in 2015-2016</a></li>
+<li><a href="https://nshipster.com/propertywrapper/">NSHipster article</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h3><a href="https://instabug.com/swift?utm_source=swift&amp;utm_medium=podcasts&amp;utm_campaign=swiftunwrapped-podcasts-q319-July">Instabug</a></h3>
+<p>Squash bugs in less than a minute with Instabug. Get a <a href="https://instabug.com/swift?utm_source=swift&amp;utm_medium=podcasts&amp;utm_campaign=swiftunwrapped-podcasts-q319-July">14-days trial and their brand new t-shirt</a> once you signup and integrate Instabug in your app.</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="30380815" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/234e904c-9511-47ee-9fa8-658b58c60878/76_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>76: Property Wrappers</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/234e904c-9511-47ee-9fa8-658b58c60878/3000x3000/1561865782-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:31:34</itunes:duration>
+      <itunes:summary>A concept that&apos;s been in and out of conversation for Swift since 2015, property behaviors - uh, delegates - uh, wrappers - are now back with the full weight of SwiftUI behind it.</itunes:summary>
+      <itunes:subtitle>A concept that&apos;s been in and out of conversation for Swift since 2015, property behaviors - uh, delegates - uh, wrappers - are now back with the full weight of SwiftUI behind it.</itunes:subtitle>
+      <itunes:keywords>apple, behaviors, instabug, property wrappers, clubhouse, swift, open source, programming language, programming, kotlin, compiler, swift evolution, xcode, delegates</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>77</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">b4623410-2b01-4b1a-9102-57983a4a2d05</guid>
+      <title>75: Swift Build Systems w/ Keith Smiley</title>
+      <description><![CDATA[<h2>Links</h2>
+<ul>
+<li><a href="https://github.com/yonaskolb/XcodeGen">XcodeGen</a></li>
+<li><a href="https://forums.swift.org/t/announcing-swift-support-in-cmake/24792">Announcing Swift support in CMake</a></li>
+<li><a href="https://buck.build/">Buck</a></li>
+<li><a href="https://bazel.build/">Bazel</a></li>
+<li><a href="https://github.com/bazelbuild/rules_apple">Bazel's Apple platform rules</a></li>
+<li><a href="https://github.com/apple/swift-llbuild">llbuild</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://www.sentry.io/for/swift">Sentry.io</a></h3>
+<p>Sentry tells you about errors in your code before your customers have a chance to encounter them.</p>
+<p>With Sentry, you’ll see exactly how many users have been impacted by a bug, the stack trace, the commit that the error was released as part of, the engineer who wrote the line of code that is currently busted, and a lot more.</p>
+<p>Give it a try and let them know we sent you at https://www.sentry.io/for/swift</p>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Sun, 2 Jun 2019 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h2>Links</h2>
+<ul>
+<li><a href="https://github.com/yonaskolb/XcodeGen">XcodeGen</a></li>
+<li><a href="https://forums.swift.org/t/announcing-swift-support-in-cmake/24792">Announcing Swift support in CMake</a></li>
+<li><a href="https://buck.build/">Buck</a></li>
+<li><a href="https://bazel.build/">Bazel</a></li>
+<li><a href="https://github.com/bazelbuild/rules_apple">Bazel's Apple platform rules</a></li>
+<li><a href="https://github.com/apple/swift-llbuild">llbuild</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://www.sentry.io/for/swift">Sentry.io</a></h3>
+<p>Sentry tells you about errors in your code before your customers have a chance to encounter them.</p>
+<p>With Sentry, you’ll see exactly how many users have been impacted by a bug, the stack trace, the commit that the error was released as part of, the engineer who wrote the line of code that is currently busted, and a lot more.</p>
+<p>Give it a try and let them know we sent you at https://www.sentry.io/for/swift</p>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="26943019" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/bad49a09-7e7d-442f-984f-3234da02fa5a/75-build-systems-w-keith-smiley_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>75: Swift Build Systems w/ Keith Smiley</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/bad49a09-7e7d-442f-984f-3234da02fa5a/3000x3000/1559446118-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:27:59</itunes:duration>
+      <itunes:summary>In this episode with special guest Keith Smiley, we cover the growing number of  tools that let you build things in Swift, a few of which are made by Apple, as well as some others like CMake, Bazel and Buck.</itunes:summary>
+      <itunes:subtitle>In this episode with special guest Keith Smiley, we cover the growing number of  tools that let you build things in Swift, a few of which are made by Apple, as well as some others like CMake, Bazel and Buck.</itunes:subtitle>
+      <itunes:keywords>buck, llbuild, compiler, sentry, swift, open source, clubhouse, build systems, apple, programming, xcodegen, cmake, xcode, bazel</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>76</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">b679f66f-0236-4afc-a4df-cbbb372a858e</guid>
+      <title>74: Removing Things From Swift</title>
+      <description><![CDATA[<h2>Relevant Links</h2>
+<ul>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0255-omit-return.md">SE-0255: Implicit returns from single-expression functions</a>
+<ul>
+<li><a href="https://twitter.com/AirspeedSwift/status/1108902065634328581">Tweet from Ben Cohen</a></li>
+<li><a href="https://forums.swift.org/t/accepted-se-0255-implicit-returns-from-single-expression-functions/23581">Swift Forums Acceptance Post</a></li>
+</ul>
+</li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0257-elide-comma.md">SE-0257: Eliding commas from multiline expression lists</a></li>
+<li><a href="https://github.com/yonaskolb/Mint">Swift Mint</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://www.sentry.io/for/swift">Sentry.io</a></h3>
+<p>Sentry tells you about errors in your code before your customers have a chance to encounter them.</p>
+<p>With Sentry, you’ll see exactly how many users have been impacted by a bug, the stack trace, the commit that the error was released as part of, the engineer who wrote the line of code that is currently busted, and a lot more.</p>
+<p>Give it a try and let them know we sent you at https://www.sentry.io/for/swift</p>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 6 May 2019 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h2>Relevant Links</h2>
+<ul>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0255-omit-return.md">SE-0255: Implicit returns from single-expression functions</a>
+<ul>
+<li><a href="https://twitter.com/AirspeedSwift/status/1108902065634328581">Tweet from Ben Cohen</a></li>
+<li><a href="https://forums.swift.org/t/accepted-se-0255-implicit-returns-from-single-expression-functions/23581">Swift Forums Acceptance Post</a></li>
+</ul>
+</li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0257-elide-comma.md">SE-0257: Eliding commas from multiline expression lists</a></li>
+<li><a href="https://github.com/yonaskolb/Mint">Swift Mint</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://www.sentry.io/for/swift">Sentry.io</a></h3>
+<p>Sentry tells you about errors in your code before your customers have a chance to encounter them.</p>
+<p>With Sentry, you’ll see exactly how many users have been impacted by a bug, the stack trace, the commit that the error was released as part of, the engineer who wrote the line of code that is currently busted, and a lot more.</p>
+<p>Give it a try and let them know we sent you at https://www.sentry.io/for/swift</p>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="33463274" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/6a1f3e80-2343-4c5e-ac0e-53a8ceea62b5/74_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>74: Removing Things From Swift</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/6a1f3e80-2343-4c5e-ac0e-53a8ceea62b5/3000x3000/1557116919-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:34:47</itunes:duration>
+      <itunes:summary>Although we usually discuss new features being added to Swift, this episode is all about removing things from the language.</itunes:summary>
+      <itunes:subtitle>Although we usually discuss new features being added to Swift, this episode is all about removing things from the language.</itunes:subtitle>
+      <itunes:keywords>mint, clubhouse, apple, commas, swift, open source, syntax, programming, return statements, boilerplate, xcode, compiler, sentry</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>75</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">2e49ccf2-62da-4dfa-838b-8ff5e5cd8c08</guid>
+      <title>73: UTF-8 Strings in Swift 5</title>
+      <description><![CDATA[<h2>Relevant Links</h2>
+<ul>
+<li><a href="https://swift.org/blog/utf8-string/">UTF-8 String blog post on swift.org</a></li>
+<li><a href="https://forums.swift.org/t/piercing-the-string-veil/21700">Piercing the String Veil post on Swift forums</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0241-string-index-explicit-encoding-offset.md">SE-241 Deprecate String Index Encoded Offsets</a></li>
+<li><a href="https://bugs.swift.org/browse/SR-9749">SR-9749: The bug that led to deprecating <code>encodedOffset</code></a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://www.sentry.io/for/swift">Sentry.io</a></h3>
+<p>Sentry tells you about errors in your code before your customers have a chance to encounter them.</p>
+<p>With Sentry, you’ll see exactly how many users have been impacted by a bug, the stack trace, the commit that the error was released as part of, the engineer who wrote the line of code that is currently busted, and a lot more.</p>
+<p>Give it a try and let them know we sent you at https://www.sentry.io/for/swift</p>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 1 Apr 2019 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h2>Relevant Links</h2>
+<ul>
+<li><a href="https://swift.org/blog/utf8-string/">UTF-8 String blog post on swift.org</a></li>
+<li><a href="https://forums.swift.org/t/piercing-the-string-veil/21700">Piercing the String Veil post on Swift forums</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0241-string-index-explicit-encoding-offset.md">SE-241 Deprecate String Index Encoded Offsets</a></li>
+<li><a href="https://bugs.swift.org/browse/SR-9749">SR-9749: The bug that led to deprecating <code>encodedOffset</code></a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://www.sentry.io/for/swift">Sentry.io</a></h3>
+<p>Sentry tells you about errors in your code before your customers have a chance to encounter them.</p>
+<p>With Sentry, you’ll see exactly how many users have been impacted by a bug, the stack trace, the commit that the error was released as part of, the engineer who wrote the line of code that is currently busted, and a lot more.</p>
+<p>Give it a try and let them know we sent you at https://www.sentry.io/for/swift</p>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="25377849" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7e3b0edd-7187-4200-93a7-fb04b40598cf/project-73_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>73: UTF-8 Strings in Swift 5</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7e3b0edd-7187-4200-93a7-fb04b40598cf/3000x3000/1553811506-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:26:22</itunes:duration>
+      <itunes:summary></itunes:summary>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:keywords>apple, swift, open source, encodings, strings, clubhouse, utf-16, programming, sentry, compiler, xcode, nsstring, utf-8</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>74</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">05f1541a-0489-4b63-8512-fa06fa6649ca</guid>
+      <title>72: Pitch for Official Style Guide &amp; Formatter for Swift</title>
+      <description><![CDATA[<h2>Relevant Links</h2>
+<ul>
+<li><a href="https://forums.swift.org/t/pitch-an-official-style-guide-and-formatter-for-swift/21025">Swift Forums Pitch: an Official Style Guide and Formatter for Swift</a></li>
+<li><a href="https://github.com/apple/swift-evolution/pull/994">Swift Evolution PR #994</a></li>
+<li><a href="https://github.com/google/swift/tree/format">swift-format implementation</a></li>
+<li>Community Tools
+<ul>
+<li><a href="https://github.com/realm/SwiftLint">SwiftLint</a></li>
+<li><a href="https://github.com/nicklockwood/SwiftFormat">SwiftFormat</a></li>
+</ul>
+</li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://www.sentry.io/for/swift">Sentry.io</a></h3>
+<p>Sentry tells you about errors in your code before your customers have a chance to encounter them.</p>
+<p>With Sentry, you’ll see exactly how many users have been impacted by a bug, the stack trace, the commit that the error was released as part of, the engineer who wrote the line of code that is currently busted, and a lot more.</p>
+<p>Give it a try and let them know we sent you at https://www.sentry.io/for/swift</p>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 4 Mar 2019 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h2>Relevant Links</h2>
+<ul>
+<li><a href="https://forums.swift.org/t/pitch-an-official-style-guide-and-formatter-for-swift/21025">Swift Forums Pitch: an Official Style Guide and Formatter for Swift</a></li>
+<li><a href="https://github.com/apple/swift-evolution/pull/994">Swift Evolution PR #994</a></li>
+<li><a href="https://github.com/google/swift/tree/format">swift-format implementation</a></li>
+<li>Community Tools
+<ul>
+<li><a href="https://github.com/realm/SwiftLint">SwiftLint</a></li>
+<li><a href="https://github.com/nicklockwood/SwiftFormat">SwiftFormat</a></li>
+</ul>
+</li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://www.sentry.io/for/swift">Sentry.io</a></h3>
+<p>Sentry tells you about errors in your code before your customers have a chance to encounter them.</p>
+<p>With Sentry, you’ll see exactly how many users have been impacted by a bug, the stack trace, the commit that the error was released as part of, the engineer who wrote the line of code that is currently busted, and a lot more.</p>
+<p>Give it a try and let them know we sent you at https://www.sentry.io/for/swift</p>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="38831987" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/187ac56a-0044-47bb-bd37-cf08d274ae77/72-official-styleguide-and-formatter_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>72: Pitch for Official Style Guide &amp; Formatter for Swift</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/187ac56a-0044-47bb-bd37-cf08d274ae77/3000x3000/1551583593-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:40:22</itunes:duration>
+      <itunes:summary>In what is sure to lead to significant community discussion, there&apos;s now a pitch for adding a style guide and formatter to Swift.
+​</itunes:summary>
+      <itunes:subtitle>In what is sure to lead to significant community discussion, there&apos;s now a pitch for adding a style guide and formatter to Swift.
+​</itunes:subtitle>
+      <itunes:keywords>formatting, clubhouse, swift, formatter, sentry, open source, apple, linter, programming, swift-syntax, linting, swiftsyntax, xcode, syntax, style, compiler</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>73</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">9ad3d84a-aabf-47d3-83f0-ec7b6ced529d</guid>
+      <title>71: Key Path Expressions as Functions</title>
+      <description><![CDATA[<h2>Relevant Links</h2>
+<ul>
+<li>Key Path Expressions as Functions: https://forums.swift.org/t/key-path-expressions-as-functions/19587</li>
+<li>Implementation: https://github.com/apple/swift/pull/19448</li>
+<li>Previous discussion threads:
+<ul>
+<li>https://forums.swift.org/t/allow-key-path-literal-syntax-in-expressions-expecting-function-type/16453</li>
+<li>https://forums.swift.org/t/key-path-getter-promotion/11185</li>
+<li>https://forums.swift.org/t/pitch-keypath-based-map-flatmap-filter/6266</li>
+</ul>
+</li>
+<li>Original &quot;Smart Key Path&quot; proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0161-key-paths.md</li>
+<li>Kuery: https://github.com/kishikawakatsumi/Kuery</li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://www.sentry.io/for/swift">Sentry.io</a></h3>
+<p>Sentry tells you about errors in your code before your customers have a chance to encounter them.</p>
+<p>With Sentry, you’ll see exactly how many users have been impacted by a bug, the stack trace, the commit that the error was released as part of, the engineer who wrote the line of code that is currently busted, and a lot more.</p>
+<p>Give it a try and let them know we sent you at https://www.sentry.io/for/swift</p>
+<h3><a href="https://instabug.com/swift">Instabug</a></h3>
+<p>With Instabug, your users and beta testers now can submit thorough feedback from your app by just shaking the phone, they will be able to take a screenshot and send their feedback easily.</p>
+<p>You will receive a t-shirt with their motto 'I squash bugs for a living' if you go to <a href="https://instabug.com/swift">instabug.com/swift</a>, signup, and integrate the SDK.</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 4 Feb 2019 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h2>Relevant Links</h2>
+<ul>
+<li>Key Path Expressions as Functions: https://forums.swift.org/t/key-path-expressions-as-functions/19587</li>
+<li>Implementation: https://github.com/apple/swift/pull/19448</li>
+<li>Previous discussion threads:
+<ul>
+<li>https://forums.swift.org/t/allow-key-path-literal-syntax-in-expressions-expecting-function-type/16453</li>
+<li>https://forums.swift.org/t/key-path-getter-promotion/11185</li>
+<li>https://forums.swift.org/t/pitch-keypath-based-map-flatmap-filter/6266</li>
+</ul>
+</li>
+<li>Original &quot;Smart Key Path&quot; proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0161-key-paths.md</li>
+<li>Kuery: https://github.com/kishikawakatsumi/Kuery</li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://www.sentry.io/for/swift">Sentry.io</a></h3>
+<p>Sentry tells you about errors in your code before your customers have a chance to encounter them.</p>
+<p>With Sentry, you’ll see exactly how many users have been impacted by a bug, the stack trace, the commit that the error was released as part of, the engineer who wrote the line of code that is currently busted, and a lot more.</p>
+<p>Give it a try and let them know we sent you at https://www.sentry.io/for/swift</p>
+<h3><a href="https://instabug.com/swift">Instabug</a></h3>
+<p>With Instabug, your users and beta testers now can submit thorough feedback from your app by just shaking the phone, they will be able to take a screenshot and send their feedback easily.</p>
+<p>You will receive a t-shirt with their motto 'I squash bugs for a living' if you go to <a href="https://instabug.com/swift">instabug.com/swift</a>, signup, and integrate the SDK.</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="27475088" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b06bf92c-00f5-48d3-bb43-b3eaae14c4fd/71-key-path-expressions-as-functional-dependencies_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>71: Key Path Expressions as Functions</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b06bf92c-00f5-48d3-bb43-b3eaae14c4fd/3000x3000/1548821422-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:28:33</itunes:duration>
+      <itunes:summary>If this proposal is accepted, we&apos;ll be seeing Key Paths in a lot more places.</itunes:summary>
+      <itunes:subtitle>If this proposal is accepted, we&apos;ll be seeing Key Paths in a lot more places.</itunes:subtitle>
+      <itunes:keywords>keypaths, metaprogramming, apple, predicate, swift, kuery, open source, key paths, programming, compiler, key-value observing, instabug, xcode, sentry, nspredicate, kvo</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>72</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">fb6292e1-5859-46da-b241-dd24dcabafb9</guid>
+      <title>70: SourceKit-LSP</title>
+      <description><![CDATA[<h2>Relevant Links</h2>
+<ul>
+<li><a href="https://forums.swift.org/t/new-lsp-language-service-supporting-swift-and-c-family-languages-for-any-editor-and-platform/17024">Announcement Post on Swift Forums</a></li>
+<li><a href="https://forums.swift.org/t/introducing-sourcekit-lsp/17964">Open Sourcing Post on Swift Forums</a></li>
+<li>GitHub Repository: <a href="https://github.com/apple/sourcekit-lsp">apple/sourcekit-lsp</a></li>
+<li><a href="https://nshipster.com/vscode">NSHipster article on Swift Development with Visual Studio Code using SourceKit-LSP</a></li>
+<li><a href="https://microsoft.github.io/language-server-protocol">Language Server Protocol Website</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://www.sentry.io/for/swift">Sentry.io</a></h3>
+<p>Sentry tells you about errors in your code before your customers have a chance to encounter them.</p>
+<p>With Sentry, you’ll see exactly how many users have been impacted by a bug, the stack trace, the commit that the error was released as part of, the engineer who wrote the line of code that is currently busted, and a lot more.</p>
+<p>Give it a try and let them know we sent you at: https://www.sentry.io/for/swift</p>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 7 Jan 2019 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h2>Relevant Links</h2>
+<ul>
+<li><a href="https://forums.swift.org/t/new-lsp-language-service-supporting-swift-and-c-family-languages-for-any-editor-and-platform/17024">Announcement Post on Swift Forums</a></li>
+<li><a href="https://forums.swift.org/t/introducing-sourcekit-lsp/17964">Open Sourcing Post on Swift Forums</a></li>
+<li>GitHub Repository: <a href="https://github.com/apple/sourcekit-lsp">apple/sourcekit-lsp</a></li>
+<li><a href="https://nshipster.com/vscode">NSHipster article on Swift Development with Visual Studio Code using SourceKit-LSP</a></li>
+<li><a href="https://microsoft.github.io/language-server-protocol">Language Server Protocol Website</a></li>
+</ul>
+<h2>Thanks to this episode's Sponsors</h2>
+<h3><a href="https://www.sentry.io/for/swift">Sentry.io</a></h3>
+<p>Sentry tells you about errors in your code before your customers have a chance to encounter them.</p>
+<p>With Sentry, you’ll see exactly how many users have been impacted by a bug, the stack trace, the commit that the error was released as part of, the engineer who wrote the line of code that is currently busted, and a lot more.</p>
+<p>Give it a try and let them know we sent you at: https://www.sentry.io/for/swift</p>
+<h3><a href="https://clubhouse.io/swiftunwrapped">Clubhouse.io</a></h3>
+<p>Clubhouse is the first project management platform for software development that brings everyone together so that teams can focus on what matters – creating products their customers love.</p>
+<p>With a simple API and robust set of integrations, Clubhouse seamlessly integrates with the tools you use every day, getting out of your way so that you can deliver quality software on time.</p>
+<p>Listeners of Swift Unwrapped can sign up for <strong>two free months</strong> of Clubhouse by visiting https://clubhouse.io/swiftunwrapped</p>
+<h2>Get in Touch</h2>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="19523053" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8cdd945e-9641-42a4-a8ba-7b79fc8f3404/70-sourcekit-lsp_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>70: SourceKit-LSP</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8cdd945e-9641-42a4-a8ba-7b79fc8f3404/3000x3000/1546304987-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:20:16</itunes:duration>
+      <itunes:summary>The Swift project is working on official support for the industry-standard Language Server Protocol and we can barely contain our excitement.</itunes:summary>
+      <itunes:subtitle>The Swift project is working on official support for the industry-standard Language Server Protocol and we can barely contain our excitement.</itunes:subtitle>
+      <itunes:keywords>swift, open source, language server protocol, programming, apple, lsp, xcode, sourcekit, sourcekit-lsp, compiler</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>71</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">053fcee9-c01c-4eb3-a006-357acfe14f02</guid>
+      <title>69: Result</title>
+      <description><![CDATA[<ul>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md">Proposal</a></li>
+<li><a href="https://forums.swift.org/t/se-0235-add-result-to-the-standard-library/17752">Forums review phase one</a></li>
+<li><a href="https://forums.swift.org/t/revised-se-0235-add-result-to-the-standard-library/18371">Forums review phase two</a><br />
+​* <a href="https://github.com/apple/swift/pull/20958">Implementation</a></li>
+<li><a href="https://medium.com/@naveenkumarmuguda/railway-oriented-programming-a-powerful-functional-programming-pattern-ab454e467f31">Railway Oriented Programming</a></li>
+</ul>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 3 Dec 2018 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md">Proposal</a></li>
+<li><a href="https://forums.swift.org/t/se-0235-add-result-to-the-standard-library/17752">Forums review phase one</a></li>
+<li><a href="https://forums.swift.org/t/revised-se-0235-add-result-to-the-standard-library/18371">Forums review phase two</a><br />
+​* <a href="https://github.com/apple/swift/pull/20958">Implementation</a></li>
+<li><a href="https://medium.com/@naveenkumarmuguda/railway-oriented-programming-a-powerful-functional-programming-pattern-ab454e467f31">Railway Oriented Programming</a></li>
+</ul>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="24471594" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/43ae0c67-df77-48fb-8591-b7595e53661e/69-proposal-to-add-restult_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>69: Result</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/43ae0c67-df77-48fb-8591-b7595e53661e/3000x3000/1543733633-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:25:25</itunes:duration>
+      <itunes:summary>It&apos;s the most wonderful time of the year again... the time when the Swift community considers adding a Result type to the standard library. Except that this time it&apos;ll probably work!</itunes:summary>
+      <itunes:subtitle>It&apos;s the most wonderful time of the year again... the time when the Swift community considers adding a Result type to the standard library. Except that this time it&apos;ll probably work!</itunes:subtitle>
+      <itunes:keywords>swift, open source, result, programming, xcode, railway oriented programming, apple, compiler</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>70</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">3d7e278d-c4c2-4d75-baa9-e4596e0f2801</guid>
+      <title>68: Opaque Result Types</title>
+      <description><![CDATA[<ul>
+<li>https://forums.swift.org/t/opaque-result-types/15645</li>
+<li>LazyMapCollection: https://cocoacasts.com/what-is-a-lazymapcollection-in-swift​</li>
+</ul>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+<h3>Thank you to <a href="https://instabug.com/swift">Instabug</a> for sponsoring this episode!</h3>
+<p>Instabug is the simplest yet most comprehensive bug reporting and In-app feedback SDK. JP uses it at Lyft and it's proven to be a critical tool!</p>
+<p>Now, Swift Unwrapped listeners will get a free t-shirt when they sign up at <a href="https://instabug.com/swift">https://instabug.com/swift</a>.</p>
+]]></description>
+      <pubDate>Mon, 5 Nov 2018 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>https://forums.swift.org/t/opaque-result-types/15645</li>
+<li>LazyMapCollection: https://cocoacasts.com/what-is-a-lazymapcollection-in-swift​</li>
+</ul>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+<h3>Thank you to <a href="https://instabug.com/swift">Instabug</a> for sponsoring this episode!</h3>
+<p>Instabug is the simplest yet most comprehensive bug reporting and In-app feedback SDK. JP uses it at Lyft and it's proven to be a critical tool!</p>
+<p>Now, Swift Unwrapped listeners will get a free t-shirt when they sign up at <a href="https://instabug.com/swift">https://instabug.com/swift</a>.</p>
+]]></content:encoded>
+      <enclosure length="15809542" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/033cae49-ad27-456e-b678-c2c062191461/68-opaque-result-types_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>68: Opaque Result Types</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/033cae49-ad27-456e-b678-c2c062191461/3000x3000/1541382828-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:16:24</itunes:duration>
+      <itunes:summary>In this episode, Jesse and JP dive in to opaque result types, which could help prevent leaking of implementation details to library consumers.</itunes:summary>
+      <itunes:subtitle>In this episode, Jesse and JP dive in to opaque result types, which could help prevent leaking of implementation details to library consumers.</itunes:subtitle>
+      <itunes:keywords>api design, type theory, swift, open source, apple, compiler, programming, types, existentials, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>69</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">b77d686e-4fe8-4bf9-a546-97a2df927505</guid>
+      <title>67: Raw Strings</title>
+      <description><![CDATA[<ul>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0200-raw-string-escaping.md">SE-0200 Enhancing String Literals Delimiters to Support Raw Text</a></li>
+<li><a href="https://github.com/twostraws/whats-new-in-swift-5-0">Paul Hudson’s What’s New in Swift 5 Playground</a></li>
+<li><a href="https://forums.swift.org/t/se-0200-enhancing-string-literals-delimiters-to-support-raw-text/15420">Discussion thread</a></li>
+<li><a href="https://forums.swift.org/t/accepted-se-0200-enhancing-string-literals-delimiters-to-support-raw-text/15822/2">Announcement thread</a></li>
+<li><a href="https://github.com/apple/swift/pull/17668">Implementation</a></li>
+</ul>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+<h3>Thank you to <a href="https://instabug.com/swift">Instabug</a> for sponsoring this episode!</h3>
+<p>Instabug is the simplest yet most comprehensive bug reporting and In-app feedback SDK. JP uses it at Lyft and it's proven to be a critical tool!</p>
+<p>Now, Swift Unwrapped listeners will get a free t-shirt when they sign up at <a href="https://instabug.com/swift">https://instabug.com/swift</a>.</p>
+]]></description>
+      <pubDate>Mon, 15 Oct 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0200-raw-string-escaping.md">SE-0200 Enhancing String Literals Delimiters to Support Raw Text</a></li>
+<li><a href="https://github.com/twostraws/whats-new-in-swift-5-0">Paul Hudson’s What’s New in Swift 5 Playground</a></li>
+<li><a href="https://forums.swift.org/t/se-0200-enhancing-string-literals-delimiters-to-support-raw-text/15420">Discussion thread</a></li>
+<li><a href="https://forums.swift.org/t/accepted-se-0200-enhancing-string-literals-delimiters-to-support-raw-text/15822/2">Announcement thread</a></li>
+<li><a href="https://github.com/apple/swift/pull/17668">Implementation</a></li>
+</ul>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+<h3>Thank you to <a href="https://instabug.com/swift">Instabug</a> for sponsoring this episode!</h3>
+<p>Instabug is the simplest yet most comprehensive bug reporting and In-app feedback SDK. JP uses it at Lyft and it's proven to be a critical tool!</p>
+<p>Now, Swift Unwrapped listeners will get a free t-shirt when they sign up at <a href="https://instabug.com/swift">https://instabug.com/swift</a>.</p>
+]]></content:encoded>
+      <enclosure length="27169628" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/41fe97d1-9d3e-43a5-9691-25bdd82c0779/67-raw-string_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>67: Raw Strings</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/41fe97d1-9d3e-43a5-9691-25bdd82c0779/3000x3000/1539555179-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:28:14</itunes:duration>
+      <itunes:summary>String literals are the gift that keep on giving with each Swift version, and Swift 5 is no exception, with raw strings.</itunes:summary>
+      <itunes:subtitle>String literals are the gift that keep on giving with each Swift version, and Swift 5 is no exception, with raw strings.</itunes:subtitle>
+      <itunes:keywords>multiline strings, swift, open source, swift evolution, evolution, strings, programming, compiler, apple, xcode, raw strings</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>68</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">47c13621-b500-4f50-ace1-653d77ff47b0</guid>
+      <title>66: Plan For Module Stability</title>
+      <description><![CDATA[<ul>
+<li>https://forums.swift.org/t/plan-for-module-stability/14551</li>
+</ul>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+<h3>Thank you to <a href="https://instabug.com/swift">Instabug</a> for sponsoring this episode!</h3>
+<p>Instabug is the simplest yet most comprehensive bug reporting and In-app feedback SDK. JP uses it at Lyft and it's proven to be a critical tool!</p>
+<p>Now, Swift Unwrapped listeners will get a free t-shirt when they sign up at <a href="https://instabug.com/swift">https://instabug.com/swift</a>.</p>
+]]></description>
+      <pubDate>Mon, 20 Aug 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>https://forums.swift.org/t/plan-for-module-stability/14551</li>
+</ul>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+<h3>Thank you to <a href="https://instabug.com/swift">Instabug</a> for sponsoring this episode!</h3>
+<p>Instabug is the simplest yet most comprehensive bug reporting and In-app feedback SDK. JP uses it at Lyft and it's proven to be a critical tool!</p>
+<p>Now, Swift Unwrapped listeners will get a free t-shirt when they sign up at <a href="https://instabug.com/swift">https://instabug.com/swift</a>.</p>
+]]></content:encoded>
+      <enclosure length="32794939" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8ba0546f-7f40-4469-a211-1027b5ac86e2/project-66_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>66: Plan For Module Stability</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8ba0546f-7f40-4469-a211-1027b5ac86e2/3000x3000/1534610922-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:34:06</itunes:duration>
+      <itunes:summary>We discuss Jordan Rose&apos;s recent forums post on a proposed plan for module stability.</itunes:summary>
+      <itunes:subtitle>We discuss Jordan Rose&apos;s recent forums post on a proposed plan for module stability.</itunes:subtitle>
+      <itunes:keywords>apple, swift, open source, abi stability, programming, module stability, compiler, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>67</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">f77be881-d6a2-4935-af75-d93276403c40</guid>
+      <title>65: Literal Initialization Via Coercion</title>
+      <description><![CDATA[<ul>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0213-literal-init-via-coercion.md">SE-0213: Literal initialization via coercion</a></li>
+<li><a href="https://github.com/apple/swift/pull/15311">Implementation (apple/swift#15311)</a></li>
+<li><a href="https://forums.swift.org/t/literal-initialization-via-coercion/11251">Swift evolution thread</a></li>
+</ul>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 2 Jul 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0213-literal-init-via-coercion.md">SE-0213: Literal initialization via coercion</a></li>
+<li><a href="https://github.com/apple/swift/pull/15311">Implementation (apple/swift#15311)</a></li>
+<li><a href="https://forums.swift.org/t/literal-initialization-via-coercion/11251">Swift evolution thread</a></li>
+</ul>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="9516326" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a79347e7-d080-48db-9e7a-dec3f1426db5/65-literal-initialization-via-coercion_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>65: Literal Initialization Via Coercion</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a79347e7-d080-48db-9e7a-dec3f1426db5/3000x3000/1529888289-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:09:50</itunes:duration>
+      <itunes:summary>A recent type checking speedup had very small source compatibility breakages, but nonetheless went through the evolution process and it was accepted!</itunes:summary>
+      <itunes:subtitle>A recent type checking speedup had very small source compatibility breakages, but nonetheless went through the evolution process and it was accepted!</itunes:subtitle>
+      <itunes:keywords>swift, open source, null, cast, swift evolution, programming, type conversion, nullable, nil, compiler, xcode, evolution, apple</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>66</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">701530bb-e36e-402b-bfa9-03306533967b</guid>
+      <title>64: Never</title>
+      <description><![CDATA[<ul>
+<li><code>Never</code> &amp; <code>absurd()</code>: https://twitter.com/pteasima/status/978325590397906944</li>
+<li>Point Free Episode #9 Algebraic Data Types: Exponents – https://www.pointfree.co/episodes/ep9-algebraic-data-types-exponents</li>
+<li>https://twitter.com/pointfreeco</li>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0215-conform-never-to-hashable-and-equatable.md</li>
+</ul>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 25 Jun 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li><code>Never</code> &amp; <code>absurd()</code>: https://twitter.com/pteasima/status/978325590397906944</li>
+<li>Point Free Episode #9 Algebraic Data Types: Exponents – https://www.pointfree.co/episodes/ep9-algebraic-data-types-exponents</li>
+<li>https://twitter.com/pointfreeco</li>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0215-conform-never-to-hashable-and-equatable.md</li>
+</ul>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="30937092" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f7b9fbd4-a09e-4457-9abe-39458e2dcebe/64-never_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>64: Never</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f7b9fbd4-a09e-4457-9abe-39458e2dcebe/3000x3000/1529787373-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:32:09</itunes:duration>
+      <itunes:summary>The Never type has some very unique properties and behavior. We introduce the type and discuss a recent proposal (SE-215) to make it conform to Hashable and Equatable.</itunes:summary>
+      <itunes:subtitle>The Never type has some very unique properties and behavior. We introduce the type and discuss a recent proposal (SE-215) to make it conform to Hashable and Equatable.</itunes:subtitle>
+      <itunes:keywords>apple, absurd, swift, open source, algebraic data types, evolution, programming, never, type theory, xcode, compiler</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>65</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">917b632e-b68f-4d97-89db-1dcc1791ea0a</guid>
+      <title>63: Swift algorithms and data structures (feat. Kelvin Lau &amp; Vincent Ngo)</title>
+      <description><![CDATA[<ul>
+<li>Data Structures and Algorithms in Swift: https://store.raywenderlich.com/products/data-structures-and-algorithms-in-swift</li>
+<li>Swift Algorithm Club: https://github.com/raywenderlich/swift-algorithm-club</li>
+<li>Ben Cohen on Sorted collections: https://bugs.swift.org/browse/SR-6865</li>
+<li>Linked list proposal: https://forums.swift.org/t/proposal-singly-and-doubly-linked-list-collections-in-standard-library/11426</li>
+</ul>
+<p>Twitter:</p>
+<ul>
+<li>Kelvin Lau: https://twitter.com/KelvinlauKl</li>
+<li>Vincent Ngo: https://twitter.com/VincentNgo2</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 18 Jun 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Data Structures and Algorithms in Swift: https://store.raywenderlich.com/products/data-structures-and-algorithms-in-swift</li>
+<li>Swift Algorithm Club: https://github.com/raywenderlich/swift-algorithm-club</li>
+<li>Ben Cohen on Sorted collections: https://bugs.swift.org/browse/SR-6865</li>
+<li>Linked list proposal: https://forums.swift.org/t/proposal-singly-and-doubly-linked-list-collections-in-standard-library/11426</li>
+</ul>
+<p>Twitter:</p>
+<ul>
+<li>Kelvin Lau: https://twitter.com/KelvinlauKl</li>
+<li>Vincent Ngo: https://twitter.com/VincentNgo2</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="43470224" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5dcadaf5-0987-4564-9ed9-c21e5e94dcbf/61-swift-algorithms-and-data-structures-with-kelvin-lau-and-vincent-ngo_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>63: Swift algorithms and data structures (feat. Kelvin Lau &amp; Vincent Ngo)</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5dcadaf5-0987-4564-9ed9-c21e5e94dcbf/3000x3000/1526582587-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:45:12</itunes:duration>
+      <itunes:summary>We welcome Kelvin and Vincent to the show to discuss Data Structures and Algorithms in Swift.</itunes:summary>
+      <itunes:subtitle>We welcome Kelvin and Vincent to the show to discuss Data Structures and Algorithms in Swift.</itunes:subtitle>
+      <itunes:keywords>objective-c, ray wenderlich, apple, ios, data structures, iphone, swift, open source, playgrounds, standard library, algorithms, programming, compiler, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>64</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">4f64b729-ab88-4103-b61f-d9e3da315c4c</guid>
+      <title>62: Interview with Ted Kremenek</title>
+      <description><![CDATA[<ul>
+<li>Ted Kremenek on Twitter: https://twitter.com/tkremenek</li>
+<li>Swift Evolution Dashboard of proposals implemented in Swift 4.2: https://apple.github.io/swift-evolution/#?version=4.2</li>
+<li>Swift ABI Dashboard: https://swift.org/abi-stability/</li>
+<li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
+<li>Ole Begemann's &quot;What's new in Swift 4.2&quot; playground: https://github.com/ole/whats-new-in-swift-4-2</li>
+</ul>
+]]></description>
+      <pubDate>Wed, 13 Jun 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Ted Kremenek on Twitter: https://twitter.com/tkremenek</li>
+<li>Swift Evolution Dashboard of proposals implemented in Swift 4.2: https://apple.github.io/swift-evolution/#?version=4.2</li>
+<li>Swift ABI Dashboard: https://swift.org/abi-stability/</li>
+<li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
+<li>Ole Begemann's &quot;What's new in Swift 4.2&quot; playground: https://github.com/ole/whats-new-in-swift-4-2</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="47236284" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e58dbe9c-430e-48e5-8444-65f5d2da5100/ted-kremenek_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>62: Interview with Ted Kremenek</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e58dbe9c-430e-48e5-8444-65f5d2da5100/3000x3000/1528594721-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:49:08</itunes:duration>
+      <itunes:summary>An in-depth conversation about Swift 4.2 and beyond with Ted Kremenek, Manager of the Languages and Runtimes team at Apple.</itunes:summary>
+      <itunes:subtitle>An in-depth conversation about Swift 4.2 and beyond with Ted Kremenek, Manager of the Languages and Runtimes team at Apple.</itunes:subtitle>
+      <itunes:keywords>apple, protocols, swift, open source, wwdc, programming, conditional conformance, compiler, generics, xcode, standard library</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>63</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">024615a0-98a7-404b-9ea8-12d9086ddd54</guid>
+      <title>61: WWDC reactions with Greg Heo</title>
+      <description><![CDATA[<p>This episode is a little different, where we discuss general announcements from WWDC 2018 not just limited to the Swift language. With special guest Greg Heo.</p>
+<ul>
+<li>Keynote: https://www.apple.com/apple-events/june-2018/</li>
+<li>Platforms State of the Union: https://developer.apple.com/videos/play/wwdc2018/102/</li>
+<li>https://www.apple.com/newsroom/2018/06/apple-previews-ios-12/</li>
+<li>https://www.apple.com/newsroom/2018/06/apple-introduces-macos-mojave/</li>
+<li>https://www.apple.com/newsroom/2018/06/watchos-5-adds-powerful-activity-and-communications-features-to-apple-watch/</li>
+<li>Patrick Balestra's ARKit 1.0 measurement app: https://www.youtube.com/watch?v=z7DYC_zbZCM</li>
+<li>https://twitter.com/gregheo</li>
+<li>https://swiftunboxed.com</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 11 Jun 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>This episode is a little different, where we discuss general announcements from WWDC 2018 not just limited to the Swift language. With special guest Greg Heo.</p>
+<ul>
+<li>Keynote: https://www.apple.com/apple-events/june-2018/</li>
+<li>Platforms State of the Union: https://developer.apple.com/videos/play/wwdc2018/102/</li>
+<li>https://www.apple.com/newsroom/2018/06/apple-previews-ios-12/</li>
+<li>https://www.apple.com/newsroom/2018/06/apple-introduces-macos-mojave/</li>
+<li>https://www.apple.com/newsroom/2018/06/watchos-5-adds-powerful-activity-and-communications-features-to-apple-watch/</li>
+<li>Patrick Balestra's ARKit 1.0 measurement app: https://www.youtube.com/watch?v=z7DYC_zbZCM</li>
+<li>https://twitter.com/gregheo</li>
+<li>https://swiftunboxed.com</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="41929152" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4420cdd7-d9ec-4285-b5fe-6811040df5c8/61-greg-heo-swiftunwrapped_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>61: WWDC reactions with Greg Heo</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4420cdd7-d9ec-4285-b5fe-6811040df5c8/3000x3000/1528513841-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:43:36</itunes:duration>
+      <itunes:summary>We discuss the announcements from WWDC 2018 with special guest, Greg Heo.</itunes:summary>
+      <itunes:subtitle>We discuss the announcements from WWDC 2018 with special guest, Greg Heo.</itunes:subtitle>
+      <itunes:keywords>macos mojave, swift, tvos, programming, watchos, wwdc18, wwdc, apple, software, ios 12</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>62</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">f6b9f616-d884-46f7-835a-d3f4058b417c</guid>
+      <title>60: Character Properties</title>
+      <description><![CDATA[<p>Forums:</p>
+<ul>
+<li>https://forums.swift.org/t/pitch-character-and-string-properties/11620</li>
+<li>https://forums.swift.org/t/adding-unicode-properties-to-unicodescalar-character/9310</li>
+</ul>
+<p>Pull requests:</p>
+<ul>
+<li>https://github.com/apple/swift/pull/15880</li>
+<li>https://github.com/apple/swift-evolution/pull/847</li>
+</ul>
+<p>Proposals:</p>
+<ul>
+<li>https://gist.github.com/milseman/c8c50ed0eef0a21181b0d4eeedbad819</li>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0211-unicode-scalar-properties.md</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 28 May 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>Forums:</p>
+<ul>
+<li>https://forums.swift.org/t/pitch-character-and-string-properties/11620</li>
+<li>https://forums.swift.org/t/adding-unicode-properties-to-unicodescalar-character/9310</li>
+</ul>
+<p>Pull requests:</p>
+<ul>
+<li>https://github.com/apple/swift/pull/15880</li>
+<li>https://github.com/apple/swift-evolution/pull/847</li>
+</ul>
+<p>Proposals:</p>
+<ul>
+<li>https://gist.github.com/milseman/c8c50ed0eef0a21181b0d4eeedbad819</li>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0211-unicode-scalar-properties.md</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="17403646" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/ec245c2f-8cc8-45ee-ac90-c66da8811a30/60-character-properties_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>60: Character Properties</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/ec245c2f-8cc8-45ee-ac90-c66da8811a30/3000x3000/1526069364-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:18:03</itunes:duration>
+      <itunes:summary>We discuss recent proposals on adding unicode properties to characters and Unicode.scalar.</itunes:summary>
+      <itunes:subtitle>We discuss recent proposals on adding unicode properties to characters and Unicode.scalar.</itunes:subtitle>
+      <itunes:keywords>ios, compiler, swift, open source, programming, standard library, apple, character, objective-c, xcode, iphone, unicode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>61</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">b22c2a39-e15e-49a4-9c11-0a6c40e87882</guid>
+      <title>59: Implicit Escaping of Closures</title>
+      <description><![CDATA[<h3>Links</h3>
+<ul>
+<li>Forums: https://forums.swift.org/t/implicit-escaping-of-closures-via-objective-c/12025</li>
+<li>SE-0103 Make non-escaping closures the default: https://github.com/apple/swift-evolution/blob/master/proposals/0103-make-noescape-default.md</li>
+<li>Escaping closures explained: https://swiftunboxed.com/lang/closures-escaping-noescape-swift3/</li>
+<li>Footgun tweet: https://twitter.com/dgregor79/status/987173055909715968</li>
+</ul>
+<h3>Thank you to <a href="https://instabug.com/swift">Instabug</a> for sponsoring this episode!</h3>
+<p>Instabug is the simplest yet most comprehensive bug reporting and In-app feedback SDK. JP uses it at Lyft and it's helped him out a bunch!</p>
+<p>Now, Swift Unwrapped listeners will get a 20% discount on all paid plans, use promo-code: <strong>unwrapped2018</strong></p>
+<p>Check them out, use that promo code and get 20% off at <a href="https://instabug.com/swift">https://instabug.com/swift</a></p>
+]]></description>
+      <pubDate>Mon, 21 May 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h3>Links</h3>
+<ul>
+<li>Forums: https://forums.swift.org/t/implicit-escaping-of-closures-via-objective-c/12025</li>
+<li>SE-0103 Make non-escaping closures the default: https://github.com/apple/swift-evolution/blob/master/proposals/0103-make-noescape-default.md</li>
+<li>Escaping closures explained: https://swiftunboxed.com/lang/closures-escaping-noescape-swift3/</li>
+<li>Footgun tweet: https://twitter.com/dgregor79/status/987173055909715968</li>
+</ul>
+<h3>Thank you to <a href="https://instabug.com/swift">Instabug</a> for sponsoring this episode!</h3>
+<p>Instabug is the simplest yet most comprehensive bug reporting and In-app feedback SDK. JP uses it at Lyft and it's helped him out a bunch!</p>
+<p>Now, Swift Unwrapped listeners will get a 20% discount on all paid plans, use promo-code: <strong>unwrapped2018</strong></p>
+<p>Check them out, use that promo code and get 20% off at <a href="https://instabug.com/swift">https://instabug.com/swift</a></p>
+]]></content:encoded>
+      <enclosure length="23458019" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/9d7fa712-39ad-457a-b090-ff4deabe88a2/59-escaping-closures_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>59: Implicit Escaping of Closures</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/9d7fa712-39ad-457a-b090-ff4deabe88a2/3000x3000/1526069281-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:24:22</itunes:duration>
+      <itunes:summary>Escaping or non-escaping? That is the question.</itunes:summary>
+      <itunes:subtitle>Escaping or non-escaping? That is the question.</itunes:subtitle>
+      <itunes:keywords>escaping, objective-c, ios, instabug, closures, swift, standard library, open source, compiler, apple, programming, iphone, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>60</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">3ce042c6-a39d-4616-80a6-9c00e57c2bb3</guid>
+      <title>58: Reimplementation of Implicitly Unwrapped Optionals</title>
+      <description><![CDATA[<ul>
+<li>Blog post on Reimplementation of Implicitly Unwrapped Optionals: https://swift.org/blog/iuo</li>
+<li>SE-0054 Abolish <code>ImplicitlyUnwrappedOptional</code> type: https://github.com/apple/swift-evolution/blob/master/proposals/0054-abolish-iuo.md</li>
+</ul>
+<h3>Thank you to <a href="https://instabug.com/swift">Instabug</a> for sponsoring this episode!</h3>
+<p>Instabug is the simplest yet most comprehensive bug reporting and In-app feedback SDK. JP uses it at Lyft and it's helped him out a bunch!</p>
+<p>Now, Swift Unwrapped listeners will get a 20% discount on all paid plans, use promo-code: <strong>unwrapped2018</strong></p>
+<p>Check them out, use that promo code and get 20% off at <a href="https://instabug.com/swift">https://instabug.com/swift</a></p>
+<p>Thanks Instabug!</p>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 14 May 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Blog post on Reimplementation of Implicitly Unwrapped Optionals: https://swift.org/blog/iuo</li>
+<li>SE-0054 Abolish <code>ImplicitlyUnwrappedOptional</code> type: https://github.com/apple/swift-evolution/blob/master/proposals/0054-abolish-iuo.md</li>
+</ul>
+<h3>Thank you to <a href="https://instabug.com/swift">Instabug</a> for sponsoring this episode!</h3>
+<p>Instabug is the simplest yet most comprehensive bug reporting and In-app feedback SDK. JP uses it at Lyft and it's helped him out a bunch!</p>
+<p>Now, Swift Unwrapped listeners will get a 20% discount on all paid plans, use promo-code: <strong>unwrapped2018</strong></p>
+<p>Check them out, use that promo code and get 20% off at <a href="https://instabug.com/swift">https://instabug.com/swift</a></p>
+<p>Thanks Instabug!</p>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="15924548" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/642a1037-d1c2-47a5-9d34-5e0abcb68a77/58-reimplementation-of-implicitly-unwrapped-optionals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>58: Reimplementation of Implicitly Unwrapped Optionals</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/642a1037-d1c2-47a5-9d34-5e0abcb68a77/3000x3000/1525820611-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:16:31</itunes:duration>
+      <itunes:summary>IUOs are dead, long live IUOs! With this change, IUOs are no longer a type but rather a special variant of Optional.</itunes:summary>
+      <itunes:subtitle>IUOs are dead, long live IUOs! With this change, IUOs are no longer a type but rather a special variant of Optional.</itunes:subtitle>
+      <itunes:keywords>standard library, ios, instabug, implicitly unwrapped optionals, swift, open source, programming, iuo, type systems, crash reporting, optionals, xcode, compiler, bug reporting, apple, iphone</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>59</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">60c73681-d7b9-40e4-b710-439d4b22ce26</guid>
+      <title>57: Swift for TensorFlow Design Overview</title>
+      <description><![CDATA[<ul>
+<li>https://github.com/tensorflow/swift/blob/master/docs/DesignOverview.md</li>
+<li>https://twitter.com/chriseidhof/status/989736679417171968</li>
+<li>https://twitter.com/chriseidhof/status/989573435968966658</li>
+<li>https://gist.github.com/lattner/a6257f425f55fe39fd6ac7a2354d693d</li>
+<li>https://forums.swift.org/t/pitch-3-introduce-user-defined-dynamically-callable-types/12232</li>
+<li>https://www.tensorflow.org/</li>
+<li>https://youtu.be/Yze693W4MaU</li>
+<li>https://groups.google.com/a/tensorflow.org/forum/#!topic/swift/xtXCEvtDe5Q</li>
+<li>https://www.tensorflow.org/community/swift</li>
+<li>https://twitter.com/clattner_llvm/status/979886581371740160</li>
+</ul>
+<h3>Thank you to <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w19">Bitrise.io</a> for sponsoring this episode!</h3>
+<p>Bitrise is Mobile Continuous Integration and Delivery for your whole team, with dozens of integrations for your favourite services. Be sure to check out their new <a href="https://blog.bitrise.io/ios-auto-provision-step">iOS Auto Provision step</a> for your Xcode projects.</p>
+<p>Check them out and let them know we sent you at <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w19">Bitrise.io</a></p>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 7 May 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>https://github.com/tensorflow/swift/blob/master/docs/DesignOverview.md</li>
+<li>https://twitter.com/chriseidhof/status/989736679417171968</li>
+<li>https://twitter.com/chriseidhof/status/989573435968966658</li>
+<li>https://gist.github.com/lattner/a6257f425f55fe39fd6ac7a2354d693d</li>
+<li>https://forums.swift.org/t/pitch-3-introduce-user-defined-dynamically-callable-types/12232</li>
+<li>https://www.tensorflow.org/</li>
+<li>https://youtu.be/Yze693W4MaU</li>
+<li>https://groups.google.com/a/tensorflow.org/forum/#!topic/swift/xtXCEvtDe5Q</li>
+<li>https://www.tensorflow.org/community/swift</li>
+<li>https://twitter.com/clattner_llvm/status/979886581371740160</li>
+</ul>
+<h3>Thank you to <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w19">Bitrise.io</a> for sponsoring this episode!</h3>
+<p>Bitrise is Mobile Continuous Integration and Delivery for your whole team, with dozens of integrations for your favourite services. Be sure to check out their new <a href="https://blog.bitrise.io/ios-auto-provision-step">iOS Auto Provision step</a> for your Xcode projects.</p>
+<p>Check them out and let them know we sent you at <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w19">Bitrise.io</a></p>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="39065281" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d987c101-6a78-4ae8-80c7-295b7ca5fad8/57-revisiting-tensorflow_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>57: Swift for TensorFlow Design Overview</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d987c101-6a78-4ae8-80c7-295b7ca5fad8/3000x3000/1525286307-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:40:37</itunes:duration>
+      <itunes:summary>Now that Swift for TensorFlow has been open sourced and documentation is available, we share some very interesting findings.</itunes:summary>
+      <itunes:subtitle>Now that Swift for TensorFlow has been open sourced and documentation is available, we share some very interesting findings.</itunes:subtitle>
+      <itunes:keywords>apple, tensorflow, ios, technology, tpu, swift, open source, automatic differentiation, chris lattner, playgrounds, programming, tensor, bitrise, google, compiler, development, xcode, machine learning</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>58</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">ca754556-2a30-4ecf-b1fb-f971e70b41a6</guid>
+      <title>56: SE-206 Hashable Enhancements</title>
+      <description><![CDATA[<ul>
+<li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0206-hashable-enhancements.md</li>
+<li>Swift Evolution review thread &amp; acceptance post: https://forums.swift.org/t/accepted-se-0206-hashable-enhancements/11675/115</li>
+</ul>
+<h3>Thank you to <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w18">Bitrise.io</a> for sponsoring this episode!</h3>
+<p>Bitrise is Mobile Continuous Integration and Delivery for your whole team, with dozens of integrations for your favourite services. Be sure to check out their new <a href="https://blog.bitrise.io/ios-auto-provision-step">iOS Auto Provision step</a> for your Xcode projects.</p>
+<p>Check them out and let them know we sent you at <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w18">Bitrise.io</a></p>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 30 Apr 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0206-hashable-enhancements.md</li>
+<li>Swift Evolution review thread &amp; acceptance post: https://forums.swift.org/t/accepted-se-0206-hashable-enhancements/11675/115</li>
+</ul>
+<h3>Thank you to <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w18">Bitrise.io</a> for sponsoring this episode!</h3>
+<p>Bitrise is Mobile Continuous Integration and Delivery for your whole team, with dozens of integrations for your favourite services. Be sure to check out their new <a href="https://blog.bitrise.io/ios-auto-provision-step">iOS Auto Provision step</a> for your Xcode projects.</p>
+<p>Check them out and let them know we sent you at <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w18">Bitrise.io</a></p>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="18527126" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5c213281-9104-498d-be10-d15b64a7b59f/56-se-206-hashable-enhancements_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>56: SE-206 Hashable Enhancements</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5c213281-9104-498d-be10-d15b64a7b59f/3000x3000/1524193202-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:19:13</itunes:duration>
+      <itunes:summary>Swift will soon have a more robust hashing strategy, and it doesn&apos;t involve always returning zero for hashValue.</itunes:summary>
+      <itunes:subtitle>Swift will soon have a more robust hashing strategy, and it doesn&apos;t involve always returning zero for hashValue.</itunes:subtitle>
+      <itunes:keywords>continuous delivery, hashing, ios, compiler, provisioning, swift, open source, continuous integration, standard library, programming, iphone, ci, siphash, xcode, seed, bitrise, apple</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>57</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">5f939235-3994-46ee-be98-1b2b65871fb2</guid>
+      <title>55: SE-202 Random Unification</title>
+      <description><![CDATA[<ul>
+<li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0202-random-unification.md</li>
+<li>Swift Evolution thread: https://forums.swift.org/t/proposal-random-unification/6626</li>
+<li>Implementation: https://github.com/apple/swift/pull/12772</li>
+<li>Acceptance post: https://forums.swift.org/t/accepted-se-020-random-unification/12040</li>
+</ul>
+<h3>Thank you to <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w17">Bitrise.io</a> for sponsoring this episode!</h3>
+<p>Bitrise is Mobile Continuous Integration and Delivery for your whole team, with dozens of integrations for your favourite services. Be sure to check out their new <a href="https://blog.bitrise.io/ios-auto-provision-step">iOS Auto Provision step</a> for your Xcode projects.</p>
+<p>Check them out and let them know we sent you at <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w17">Bitrise.io</a></p>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 23 Apr 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0202-random-unification.md</li>
+<li>Swift Evolution thread: https://forums.swift.org/t/proposal-random-unification/6626</li>
+<li>Implementation: https://github.com/apple/swift/pull/12772</li>
+<li>Acceptance post: https://forums.swift.org/t/accepted-se-020-random-unification/12040</li>
+</ul>
+<h3>Thank you to <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w17">Bitrise.io</a> for sponsoring this episode!</h3>
+<p>Bitrise is Mobile Continuous Integration and Delivery for your whole team, with dozens of integrations for your favourite services. Be sure to check out their new <a href="https://blog.bitrise.io/ios-auto-provision-step">iOS Auto Provision step</a> for your Xcode projects.</p>
+<p>Check them out and let them know we sent you at <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w17">Bitrise.io</a></p>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="23395003" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/da8a81c5-cf62-46b1-a7c9-1bd1e5844933/55-se-202-random-unification_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>55: SE-202 Random Unification</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/da8a81c5-cf62-46b1-a7c9-1bd1e5844933/3000x3000/1524193059-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:24:18</itunes:duration>
+      <itunes:summary>Randomness gets a long overdue Swift treatment.</itunes:summary>
+      <itunes:subtitle>Randomness gets a long overdue Swift treatment.</itunes:subtitle>
+      <itunes:keywords>continuous delivery, compiler, provisioning, ios, cryptography, swift, bitrise, open source, iphone, random, apple, programming, crypto, standard library, ci, xcode, continuous integration</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>56</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">d0b1b6b0-4564-49ff-8795-d321d2d318eb</guid>
+      <title>54: Collection &amp; Sequence Proposals</title>
+      <description><![CDATA[<ul>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0197-remove-where.md</li>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0203-rename-sequence-elements-equal.md</li>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0204-add-last-methods.md</li>
+</ul>
+<h3>Thank you to <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w16">Bitrise.io</a> for sponsoring this episode!</h3>
+<p>Bitrise is Mobile Continuous Integration and Delivery for your whole team, with dozens of integrations for your favourite services. Be sure to check out their new <a href="https://blog.bitrise.io/ios-auto-provision-step">iOS Auto Provision step</a> for your Xcode projects.</p>
+<p>Check them out and let them know we sent you at <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w16">Bitrise.io</a></p>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></description>
+      <pubDate>Mon, 16 Apr 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0197-remove-where.md</li>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0203-rename-sequence-elements-equal.md</li>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0204-add-last-methods.md</li>
+</ul>
+<h3>Thank you to <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w16">Bitrise.io</a> for sponsoring this episode!</h3>
+<p>Bitrise is Mobile Continuous Integration and Delivery for your whole team, with dozens of integrations for your favourite services. Be sure to check out their new <a href="https://blog.bitrise.io/ios-auto-provision-step">iOS Auto Provision step</a> for your Xcode projects.</p>
+<p>Check them out and let them know we sent you at <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w16">Bitrise.io</a></p>
+<h3>Get in Touch</h3>
+<p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
+<p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
+]]></content:encoded>
+      <enclosure length="22850920" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b6a3fd5d-8692-48cc-a41b-752782516396/54-collection-sequence-proposals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>54: Collection &amp; Sequence Proposals</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b6a3fd5d-8692-48cc-a41b-752782516396/3000x3000/1522870991-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:23:44</itunes:duration>
+      <itunes:summary>We cover a few recent Collection &amp; Sequence Swift Evolution proposals.</itunes:summary>
+      <itunes:subtitle>We cover a few recent Collection &amp; Sequence Swift Evolution proposals.</itunes:subtitle>
+      <itunes:keywords>ios, swift, open source, compiler, standard library, provisioning, apple, programming, ci, xcode, bitrise, continuous delivery, continuous integration, iphone</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>55</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">e0ce2fa5-6659-4e32-aaf3-eba6a7c09e64</guid>
+      <title>53: Swift for TensorFlow</title>
+      <description><![CDATA[<ul>
+<li>https://www.tensorflow.org/</li>
+<li>https://youtu.be/Yze693W4MaU</li>
+<li>https://groups.google.com/a/tensorflow.org/forum/#!topic/swift/xtXCEvtDe5Q</li>
+<li>https://www.tensorflow.org/community/swift</li>
+<li>https://twitter.com/clattner_llvm/status/979886581371740160</li>
+</ul>
+<h3>Thank you to <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w15">Bitrise.io</a> for sponsoring this episode!</h3>
+<p>Bitrise is Mobile Continuous Integration and Delivery for your whole team, with dozens of integrations for your favourite services. Be sure to check out their new <a href="https://blog.bitrise.io/ios-auto-provision-step">iOS Auto Provision step</a> for your Xcode projects.</p>
+<p>Check them out and let them know we sent you at <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w15">Bitrise.io</a></p>
+]]></description>
+      <pubDate>Mon, 9 Apr 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>https://www.tensorflow.org/</li>
+<li>https://youtu.be/Yze693W4MaU</li>
+<li>https://groups.google.com/a/tensorflow.org/forum/#!topic/swift/xtXCEvtDe5Q</li>
+<li>https://www.tensorflow.org/community/swift</li>
+<li>https://twitter.com/clattner_llvm/status/979886581371740160</li>
+</ul>
+<h3>Thank you to <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w15">Bitrise.io</a> for sponsoring this episode!</h3>
+<p>Bitrise is Mobile Continuous Integration and Delivery for your whole team, with dozens of integrations for your favourite services. Be sure to check out their new <a href="https://blog.bitrise.io/ios-auto-provision-step">iOS Auto Provision step</a> for your Xcode projects.</p>
+<p>Check them out and let them know we sent you at <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w15">Bitrise.io</a></p>
+]]></content:encoded>
+      <enclosure length="20855561" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/699546bf-f16a-49ed-bb6a-079ef994eb9d/53-swift-for-tensorflow_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>53: Swift for TensorFlow</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/699546bf-f16a-49ed-bb6a-079ef994eb9d/3000x3000/1522868085-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:21:39</itunes:duration>
+      <itunes:summary>It happened. Google forked Swift. Swift for Tensorflow has wide-reaching implications and we just had to share our thoughts.</itunes:summary>
+      <itunes:subtitle>It happened. Google forked Swift. Swift for Tensorflow has wide-reaching implications and we just had to share our thoughts.</itunes:subtitle>
+      <itunes:keywords>swift, playgrounds, open source, chris lattner, programming, tensor, compiler, google, tensorflow, tpu, xcode, bitrise, apple, machine learning</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>54</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">54c10544-44d7-4d85-92a9-a6f1fda0e80b</guid>
+      <title>52: Package Manager Proposals</title>
+      <description><![CDATA[<p>We cover two recent Swift Package Manager proposal pitches.</p>
+<ul>
+<li>https://forums.swift.org/t/package-manager-extensible-build-tools/10900</li>
+<li>https://forums.swift.org/t/package-manager-workspace/10667</li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="https://kobiton.com/swift/?utm_source=Swift_Unwrapped_Podcast&amp;utm_medium=Podcast&amp;utm_campaign=3.20_Swift_Unwrapped_Podcast&amp;utm_content=Free_iPhone_X">Kobiton</a>. Go to <a href="https://kobiton.com/swift/?utm_source=Swift_Unwrapped_Podcast&amp;utm_medium=Podcast&amp;utm_campaign=3.20_Swift_Unwrapped_Podcast&amp;utm_content=Free_iPhone_X">Kobiton.com/swift</a> and get your extra trial minutes!</p>
+]]></description>
+      <pubDate>Mon, 2 Apr 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>We cover two recent Swift Package Manager proposal pitches.</p>
+<ul>
+<li>https://forums.swift.org/t/package-manager-extensible-build-tools/10900</li>
+<li>https://forums.swift.org/t/package-manager-workspace/10667</li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="https://kobiton.com/swift/?utm_source=Swift_Unwrapped_Podcast&amp;utm_medium=Podcast&amp;utm_campaign=3.20_Swift_Unwrapped_Podcast&amp;utm_content=Free_iPhone_X">Kobiton</a>. Go to <a href="https://kobiton.com/swift/?utm_source=Swift_Unwrapped_Podcast&amp;utm_medium=Podcast&amp;utm_campaign=3.20_Swift_Unwrapped_Podcast&amp;utm_content=Free_iPhone_X">Kobiton.com/swift</a> and get your extra trial minutes!</p>
+]]></content:encoded>
+      <enclosure length="21807266" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/60121283-ed97-4b30-92e1-934aaa46a06f/52_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>52: Package Manager Proposals</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/60121283-ed97-4b30-92e1-934aaa46a06f/3000x3000/1522644170-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:22:38</itunes:duration>
+      <itunes:summary>We cover two recent Swift Package Manager proposal pitches.</itunes:summary>
+      <itunes:subtitle>We cover two recent Swift Package Manager proposal pitches.</itunes:subtitle>
+      <itunes:keywords>apple, build systems, ios, swift, build tools, open source, iphone, kobiton, spm, programming, command line, swiftpm, compiler, llbuild, xcode, swift package manager</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>53</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">3e48ff71-dd0c-4e68-a4ed-3b2c4d652a0c</guid>
+      <title>51: Swift 4.1 w/ Doug &amp; Ben (part 2)</title>
+      <description><![CDATA[<ul>
+<li>Conditional conformance: https://swift.org/blog/conditional-conformance/</li>
+<li>Generics manifesto: https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md</li>
+<li>SE-143: https://github.com/apple/swift-evolution/blob/master/proposals/0143-conditional-conformances.md</li>
+<li>All 4.1 proposals: https://apple.github.io/swift-evolution/#?version=4.1</li>
+<li>4.1 code size optimizations: https://swift.org/blog/osize/</li>
+<li>Swift 4.1 release process: https://swift.org/blog/swift-4-1-release-process/</li>
+<li>Xcode 9.3 beta 4 release notes with a more comprehensive list of what's included in Swift 4.1: https://download.developer.apple.com/Developer_Tools/Xcode_9.3_beta_4/Release_Notes_for_Xcode_9.3_beta_4.pdf</li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 26 Mar 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Conditional conformance: https://swift.org/blog/conditional-conformance/</li>
+<li>Generics manifesto: https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md</li>
+<li>SE-143: https://github.com/apple/swift-evolution/blob/master/proposals/0143-conditional-conformances.md</li>
+<li>All 4.1 proposals: https://apple.github.io/swift-evolution/#?version=4.1</li>
+<li>4.1 code size optimizations: https://swift.org/blog/osize/</li>
+<li>Swift 4.1 release process: https://swift.org/blog/swift-4-1-release-process/</li>
+<li>Xcode 9.3 beta 4 release notes with a more comprehensive list of what's included in Swift 4.1: https://download.developer.apple.com/Developer_Tools/Xcode_9.3_beta_4/Release_Notes_for_Xcode_9.3_beta_4.pdf</li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="30822268" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b0d0ed63-d512-4910-8a6d-9ad8670be908/51-doug-and-ben-part-2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>51: Swift 4.1 w/ Doug &amp; Ben (part 2)</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b0d0ed63-d512-4910-8a6d-9ad8670be908/3000x3000/1521232730-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:32:02</itunes:duration>
+      <itunes:summary>We go over the Swift 4.1 release highlights with Ben Cohen and Doug Gregor from the Swift team. Part 2 of 2.</itunes:summary>
+      <itunes:subtitle>We go over the Swift 4.1 release highlights with Ben Cohen and Doug Gregor from the Swift team. Part 2 of 2.</itunes:subtitle>
+      <itunes:keywords>apple, generics, conditional conformance, swift, open source, programming, compiler, xcode, wwdc, protocols, standard library</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>52</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">814a010a-9336-4d7e-a983-cb22d7d08395</guid>
+      <title>50: Swift 4.1 w/ Doug &amp; Ben (part 1)</title>
+      <description><![CDATA[<ul>
+<li>Conditional conformance: https://swift.org/blog/conditional-conformance/</li>
+<li>Generics manifesto: https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md</li>
+<li>SE-143: https://github.com/apple/swift-evolution/blob/master/proposals/0143-conditional-conformances.md</li>
+<li>All 4.1 proposals: https://apple.github.io/swift-evolution/#?version=4.1</li>
+<li>4.1 code size optimizations: https://swift.org/blog/osize/</li>
+<li>Swift 4.1 release process: https://swift.org/blog/swift-4-1-release-process/</li>
+<li>Xcode 9.3 beta 4 release notes with a more comprehensive list of what's included in Swift 4.1: https://download.developer.apple.com/Developer_Tools/Xcode_9.3_beta_4/Release_Notes_for_Xcode_9.3_beta_4.pdf</li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 19 Mar 2018 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Conditional conformance: https://swift.org/blog/conditional-conformance/</li>
+<li>Generics manifesto: https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md</li>
+<li>SE-143: https://github.com/apple/swift-evolution/blob/master/proposals/0143-conditional-conformances.md</li>
+<li>All 4.1 proposals: https://apple.github.io/swift-evolution/#?version=4.1</li>
+<li>4.1 code size optimizations: https://swift.org/blog/osize/</li>
+<li>Swift 4.1 release process: https://swift.org/blog/swift-4-1-release-process/</li>
+<li>Xcode 9.3 beta 4 release notes with a more comprehensive list of what's included in Swift 4.1: https://download.developer.apple.com/Developer_Tools/Xcode_9.3_beta_4/Release_Notes_for_Xcode_9.3_beta_4.pdf</li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="18147541" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/c9bed05a-df75-499f-b04c-b27aec4d8e84/50-doug-and-ben-part-1_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>50: Swift 4.1 w/ Doug &amp; Ben (part 1)</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/c9bed05a-df75-499f-b04c-b27aec4d8e84/3000x3000/1521232734-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:18:50</itunes:duration>
+      <itunes:summary>We go over the Swift 4.1 release highlights with Ben Cohen and Doug Gregor from the Swift team. Part 1 of 2.</itunes:summary>
+      <itunes:subtitle>We go over the Swift 4.1 release highlights with Ben Cohen and Doug Gregor from the Swift team. Part 1 of 2.</itunes:subtitle>
+      <itunes:keywords>generics, swift, open source, apple, protocols, conditional conformance, programming, wwdc, compiler, xcode, standard library</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>51</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">2ced8418-00bd-453d-8ef7-60bae0fbe786</guid>
+      <title>49: Swift Protocol Wishlist</title>
+      <description><![CDATA[<p>In Today's episode we share thoughts on Dave DeLong's &quot;protocol wishlist&quot; for Swift and other ideas for improving Swift's protocols.</p>
+<ul>
+<li>Blogpost: https://davedelong.com/blog/2018/02/08/swift-protocols-wishlist/</li>
+<li>Tweet thread around blog post: https://twitter.com/davedelong/status/961745088668868608</li>
+<li>Dave DeLong on Twitter: https://twitter.com/davedelong</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 5 Mar 2018 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>In Today's episode we share thoughts on Dave DeLong's &quot;protocol wishlist&quot; for Swift and other ideas for improving Swift's protocols.</p>
+<ul>
+<li>Blogpost: https://davedelong.com/blog/2018/02/08/swift-protocols-wishlist/</li>
+<li>Tweet thread around blog post: https://twitter.com/davedelong/status/961745088668868608</li>
+<li>Dave DeLong on Twitter: https://twitter.com/davedelong</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="34113985" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/eedb656b-9197-47aa-b979-f53b4770bb04/49-swift-unwrapped-protocols-wishlist_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>49: Swift Protocol Wishlist</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/eedb656b-9197-47aa-b979-f53b4770bb04/3000x3000/1519426955-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:47:17</itunes:duration>
+      <itunes:summary>Thoughts on Dave DeLong&apos;s &quot;protocol wishlist&quot; for Swift and other ideas for improving Swift&apos;s protocols.</itunes:summary>
+      <itunes:subtitle>Thoughts on Dave DeLong&apos;s &quot;protocol wishlist&quot; for Swift and other ideas for improving Swift&apos;s protocols.</itunes:subtitle>
+      <itunes:keywords>compiler, objective-c, swift, type erasure, open source, programming, standard library, xcode, protocols</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>50</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">11770840-764a-4754-8e5a-7057f8f4af5a</guid>
+      <title>48: Google Summer Of Code 2018</title>
+      <description><![CDATA[<ul>
+<li>Announcement on Swift Forums: https://forums.swift.org/t/swift-to-participate-in-gsoc-2018/10147</li>
+<li>Project Ideas: https://swift.org/project-ideas/</li>
+<li>Summer of Code: https://summerofcode.withgoogle.com/</li>
+<li>Csmith: https://embed.cs.utah.edu/csmith/</li>
+<li>@PracticalSwift crasher PRs: https://github.com/apple/swift/pulls?q=is%3Apr+author%3Apracticalswift+is%3Aclosed</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 26 Feb 2018 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Announcement on Swift Forums: https://forums.swift.org/t/swift-to-participate-in-gsoc-2018/10147</li>
+<li>Project Ideas: https://swift.org/project-ideas/</li>
+<li>Summer of Code: https://summerofcode.withgoogle.com/</li>
+<li>Csmith: https://embed.cs.utah.edu/csmith/</li>
+<li>@PracticalSwift crasher PRs: https://github.com/apple/swift/pulls?q=is%3Apr+author%3Apracticalswift+is%3Aclosed</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="32448949" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/be309391-e715-4edf-a57f-4feb95fd5858/48-googlesummerofcode_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>48: Google Summer Of Code 2018</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/be309391-e715-4edf-a57f-4feb95fd5858/3000x3000/1519420967-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:33:44</itunes:duration>
+      <itunes:summary>Swift.org is officially participating in the Google Summer of Code program, and there are some great project ideas.</itunes:summary>
+      <itunes:subtitle>Swift.org is officially participating in the Google Summer of Code program, and there are some great project ideas.</itunes:subtitle>
+      <itunes:keywords>compiler, summer of code, spm, swift, open source, swift package manager, programming, google, libsyntax, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>49</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">ab7a06e7-f46a-47b1-825b-cb1afd871a69</guid>
+      <title>47: Revamping QuickLook Playground APIs</title>
+      <description><![CDATA[<ul>
+<li>
+<p>Forum discussion: http://forums.swift.org/t/se-0198-playground-quicklook-api-revamp/9448</p>
+</li>
+<li>
+<p>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0198-playground-quicklook-api-revamp.md</p>
+</li>
+<li>
+<p>Enabling Quick Look for Custom Types: https://developer.apple.com/library/content/documentation/IDEs/Conceptual/CustomClassDisplay_in_QuickLook/CH01-quick_look_for_custom_objects/CH01-quick_look_for_custom_objects.html</p>
+</li>
+<li>
+<p>Playground Support library: https://developer.apple.com/documentation/playgroundsupport</p>
+</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 19 Feb 2018 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>
+<p>Forum discussion: http://forums.swift.org/t/se-0198-playground-quicklook-api-revamp/9448</p>
+</li>
+<li>
+<p>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0198-playground-quicklook-api-revamp.md</p>
+</li>
+<li>
+<p>Enabling Quick Look for Custom Types: https://developer.apple.com/library/content/documentation/IDEs/Conceptual/CustomClassDisplay_in_QuickLook/CH01-quick_look_for_custom_objects/CH01-quick_look_for_custom_objects.html</p>
+</li>
+<li>
+<p>Playground Support library: https://developer.apple.com/documentation/playgroundsupport</p>
+</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="19570846" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/2a5c9ab9-ecd1-4211-a3b1-569ccf7775e0/47-revamp-playgrounds_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>47: Revamping QuickLook Playground APIs</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/2a5c9ab9-ecd1-4211-a3b1-569ccf7775e0/3000x3000/1517959698-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:20:19</itunes:duration>
+      <itunes:summary>We discuss Connor Wakamo&apos;s proposal to revamp the Playground QuickLook APIs</itunes:summary>
+      <itunes:subtitle>We discuss Connor Wakamo&apos;s proposal to revamp the Playground QuickLook APIs</itunes:subtitle>
+      <itunes:keywords>quicklook, swift, cocoa, playgrounds, compiler, programming, xcode, ipad</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>48</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">32e4eed3-6a18-477f-a9bb-b9056dc7fdd8</guid>
+      <title>46: Restricting cross-module struct initializers</title>
+      <description><![CDATA[<ul>
+<li>
+<p>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0189-restrict-cross-module-struct-initializers.md</p>
+</li>
+<li>
+<p>Implementation: https://github.com/apple/swift/pull/12834</p>
+</li>
+<li>
+<p>Forum accepted announcement: http://forums.swift.org/t/accepted-se-0189-restrict-cross-module-struct-initializers/7164</p>
+</li>
+<li>
+<p>Mailing list discussion: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20171120/041478.html</p>
+</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 12 Feb 2018 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>
+<p>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0189-restrict-cross-module-struct-initializers.md</p>
+</li>
+<li>
+<p>Implementation: https://github.com/apple/swift/pull/12834</p>
+</li>
+<li>
+<p>Forum accepted announcement: http://forums.swift.org/t/accepted-se-0189-restrict-cross-module-struct-initializers/7164</p>
+</li>
+<li>
+<p>Mailing list discussion: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20171120/041478.html</p>
+</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="14696554" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f3757aca-5b46-47a1-9135-a162dd64c141/46-new-proposals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>46: Restricting cross-module struct initializers</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f3757aca-5b46-47a1-9135-a162dd64c141/3000x3000/1517956756-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:15:14</itunes:duration>
+      <itunes:summary>We discuss Jordan Rose&apos;s proposal to address issues with struct initializers</itunes:summary>
+      <itunes:subtitle>We discuss Jordan Rose&apos;s proposal to address issues with struct initializers</itunes:subtitle>
+      <itunes:keywords>initializers, swift, compiler, programming, structs, jordan rose, modules, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>47</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">5a59479d-bc4c-40e6-aa1c-a4fac587b1d7</guid>
+      <title>45: Swift News January 2018</title>
+      <description><![CDATA[<ul>
+<li><code>Sequence.split</code> should have a Lazy equivalent: <a href="https://bugs.swift.org/browse/SR-6691">SR-6691</a></li>
+<li>Conditional conformance swift.org blog post: https://swift.org/blog/conditional-conformance</li>
+<li>Enforce 16-bit limit for # of function parameters, # of tuple type element: <a href="https://bugs.swift.org/browse/SR-6736">SR-6736</a></li>
+<li>Xcode 9.3 beta 1: https://developer.apple.com/news/releases/?id=01242018a</li>
+<li>Swift Playgrounds 2.0 for iPad:
+<ul>
+<li><a href="https://developer.apple.com/news/?id=01242018a">release post</a></li>
+<li><a href="https://itunes.apple.com/us/app/swift-playgrounds/id908519492">App Store</a></li>
+<li><a href="https://developer.apple.com/swift-playgrounds/subscriptions/#gallery">subscriptions</a></li>
+</ul>
+</li>
+<li>Support for <code>fallthrough</code> into cases with pattern variables: https://github.com/apple/swift/pull/14041</li>
+<li>Compiler crash fix: https://github.com/apple/swift/pull/14102</li>
+<li>Non-exhaustive enums: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0192-non-exhaustive-enums.md">SE-0192</a></li>
+<li>Derived Collection of Enum Cases: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0194-derived-collection-of-enum-cases.md">SE-0194</a></li>
+<li>Introduce User-defined “Dynamic Member Lookup” Types: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0195-dynamic-member-lookup.md">SE-0195</a></li>
+<li>Compiler Diagnostic Directives: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0196-diagnostic-directives.md">SE-0196</a></li>
+<li>Adding toggle to Bool: <a href="https://forums.swift.org/t/pitch-adding-toggle-to-bool/7414">forums discussion</a></li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 5 Feb 2018 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li><code>Sequence.split</code> should have a Lazy equivalent: <a href="https://bugs.swift.org/browse/SR-6691">SR-6691</a></li>
+<li>Conditional conformance swift.org blog post: https://swift.org/blog/conditional-conformance</li>
+<li>Enforce 16-bit limit for # of function parameters, # of tuple type element: <a href="https://bugs.swift.org/browse/SR-6736">SR-6736</a></li>
+<li>Xcode 9.3 beta 1: https://developer.apple.com/news/releases/?id=01242018a</li>
+<li>Swift Playgrounds 2.0 for iPad:
+<ul>
+<li><a href="https://developer.apple.com/news/?id=01242018a">release post</a></li>
+<li><a href="https://itunes.apple.com/us/app/swift-playgrounds/id908519492">App Store</a></li>
+<li><a href="https://developer.apple.com/swift-playgrounds/subscriptions/#gallery">subscriptions</a></li>
+</ul>
+</li>
+<li>Support for <code>fallthrough</code> into cases with pattern variables: https://github.com/apple/swift/pull/14041</li>
+<li>Compiler crash fix: https://github.com/apple/swift/pull/14102</li>
+<li>Non-exhaustive enums: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0192-non-exhaustive-enums.md">SE-0192</a></li>
+<li>Derived Collection of Enum Cases: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0194-derived-collection-of-enum-cases.md">SE-0194</a></li>
+<li>Introduce User-defined “Dynamic Member Lookup” Types: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0195-dynamic-member-lookup.md">SE-0195</a></li>
+<li>Compiler Diagnostic Directives: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0196-diagnostic-directives.md">SE-0196</a></li>
+<li>Adding toggle to Bool: <a href="https://forums.swift.org/t/pitch-adding-toggle-to-bool/7414">forums discussion</a></li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="25112089" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/225c62f6-62e0-4424-bad7-dd230e0b831a/45-recent-news_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>45: Swift News January 2018</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/225c62f6-62e0-4424-bad7-dd230e0b831a/3000x3000/1517017461-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:26:05</itunes:duration>
+      <itunes:summary>The pace is picking up early 2018, so there&apos;s a lot to cover.</itunes:summary>
+      <itunes:subtitle>The pace is picking up early 2018, so there&apos;s a lot to cover.</itunes:subtitle>
+      <itunes:keywords>split, swift, ben cohen, generics, algorithms, tuples, programming, compiler, xcode, conditional conformances</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>46</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">e465bb6d-be26-4926-92f5-fd271867f8de</guid>
+      <title>44: Swift Bi-Weekly Brief</title>
+      <description><![CDATA[<ul>
+<li>https://www.jessesquires.com/blog/swift-weekly-brief-hiatus/</li>
+<li>https://swiftweekly.github.io/issue-101/</li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 29 Jan 2018 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>https://www.jessesquires.com/blog/swift-weekly-brief-hiatus/</li>
+<li>https://swiftweekly.github.io/issue-101/</li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="11442722" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/88f0889d-a510-44c4-ab0f-559355cf98c2/44-swift-weekly-brief_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>44: Swift Bi-Weekly Brief</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/88f0889d-a510-44c4-ab0f-559355cf98c2/3000x3000/1516935519-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:11:51</itunes:duration>
+      <itunes:summary>The King is dead, long live the King!</itunes:summary>
+      <itunes:subtitle>The King is dead, long live the King!</itunes:subtitle>
+      <itunes:keywords>swift, blog, programming, xcode, newsletter</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>45</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">8fa146e0-957d-48cf-9743-7c66e3af3228</guid>
+      <title>43: State of String</title>
+      <description><![CDATA[<ul>
+<li>State of String: ABI, Performance, Ergonomics, and You! https://gist.github.com/milseman/bb39ef7f170641ae52c13600a512782f</li>
+<li>https://twitter.com/Ilseman/status/951181851229483008</li>
+<li>String Manifesto: https://github.com/apple/swift/blob/master/docs/StringManifesto.md</li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 22 Jan 2018 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>State of String: ABI, Performance, Ergonomics, and You! https://gist.github.com/milseman/bb39ef7f170641ae52c13600a512782f</li>
+<li>https://twitter.com/Ilseman/status/951181851229483008</li>
+<li>String Manifesto: https://github.com/apple/swift/blob/master/docs/StringManifesto.md</li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="23289325" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d4cf620f-3176-479f-bc09-cbcdc8b650db/43-stateofstring_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>43: State of String</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d4cf620f-3176-479f-bc09-cbcdc8b650db/3000x3000/1516065258-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:24:11</itunes:duration>
+      <itunes:summary>We dissect Michael Ilseman&apos;s recent document with potential optimizations and improvements to String in preparation for ABI stability.</itunes:summary>
+      <itunes:subtitle>We dissect Michael Ilseman&apos;s recent document with potential optimizations and improvements to String in preparation for ABI stability.</itunes:subtitle>
+      <itunes:keywords>swift, unicode, perl, programming, compiler, regex, abi, performance, xcode, strings</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>44</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">64528d7f-032c-4c48-a759-359cf291d329</guid>
+      <title>42: Conditional Conformance</title>
+      <description><![CDATA[<p>Swift 4.1 will include support for conditional protocol conformance, and we're excited to use it!</p>
+<ul>
+<li>https://swift.org/blog/conditional-conformance/</li>
+<li>https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md</li>
+<li>https://twitter.com/dgregor79/status/936353445530910720</li>
+<li>https://twitter.com/AirspeedSwift/status/936294841016762368</li>
+<li>https://twitter.com/AirspeedSwift/status/936289022766333952</li>
+<li>https://twitter.com/AirspeedSwift/status/936281530552401920</li>
+<li>https://twitter.com/simjp/status/950452640915140609</li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 15 Jan 2018 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>Swift 4.1 will include support for conditional protocol conformance, and we're excited to use it!</p>
+<ul>
+<li>https://swift.org/blog/conditional-conformance/</li>
+<li>https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md</li>
+<li>https://twitter.com/dgregor79/status/936353445530910720</li>
+<li>https://twitter.com/AirspeedSwift/status/936294841016762368</li>
+<li>https://twitter.com/AirspeedSwift/status/936289022766333952</li>
+<li>https://twitter.com/AirspeedSwift/status/936281530552401920</li>
+<li>https://twitter.com/simjp/status/950452640915140609</li>
+</ul>
+<p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="13334811" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7ac06d5e-4a1d-4a81-a03d-b486d4b40223/42-roadmaping_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>42: Conditional Conformance</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7ac06d5e-4a1d-4a81-a03d-b486d4b40223/3000x3000/1515717611-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:13:49</itunes:duration>
+      <itunes:summary>Swift 4.1 will include support for conditional protocol conformance, and we&apos;re excited to use it!</itunes:summary>
+      <itunes:subtitle>Swift 4.1 will include support for conditional protocol conformance, and we&apos;re excited to use it!</itunes:subtitle>
+      <itunes:keywords>generics, swift, optional, equatable, programming, ben cohen, compiler, codable, xcode, protocols, conditional conformances</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>43</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">552fd824-48b8-48fd-b5b8-3dc282d5c067</guid>
+      <title>41: Improving Compilation Performance</title>
+      <description><![CDATA[<ul>
+<li>Graydon Hoare’s swift-dev email: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20171113/006001.html</li>
+<li>Compiler Performance doc: https://github.com/apple/swift/blob/master/docs/CompilerPerformance.md</li>
+<li>Brian Gesiak's swift-dev email: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20171106/005934.html</li>
+</ul>
+<p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 8 Jan 2018 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Graydon Hoare’s swift-dev email: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20171113/006001.html</li>
+<li>Compiler Performance doc: https://github.com/apple/swift/blob/master/docs/CompilerPerformance.md</li>
+<li>Brian Gesiak's swift-dev email: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20171106/005934.html</li>
+</ul>
+<p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="22725539" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d3ee70a2-1165-4329-8998-b82296006fe0/41-improving-performance_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>41: Improving Compilation Performance</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d3ee70a2-1165-4329-8998-b82296006fe0/3000x3000/1513283451-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:23:36</itunes:duration>
+      <itunes:summary>We discuss the recent efforts improving &amp; instrumenting the Swift compiler&apos;s performance.</itunes:summary>
+      <itunes:subtitle>We discuss the recent efforts improving &amp; instrumenting the Swift compiler&apos;s performance.</itunes:subtitle>
+      <itunes:keywords>compilation, swift, scale tests, quadratic, continuous integration, incremental compilation, programming, performance, ci, rust, compiler, xcode, graydon hoare, brian gesiak</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>42</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">faac064d-35ee-412d-abce-e471e4a45b79</guid>
+      <title>40: Dynamic Member Lookup Proposal</title>
+      <description><![CDATA[<ul>
+<li>Introduce User-defined &quot;Dynamic Member Lookup&quot; Types:
+<ul>
+<li>First version: https://github.com/apple/swift-evolution/pull/768</li>
+<li>Second version: https://github.com/apple/swift-evolution/pull/774</li>
+</ul>
+</li>
+<li>Implementations:
+<ul>
+<li>First version: https://github.com/apple/swift/pull/13076</li>
+<li>Second version: https://github.com/apple/swift/pull/13361</li>
+</ul>
+</li>
+<li>Related &quot;dynamic callable&quot; proposal (gist in progress): https://gist.github.com/lattner/a6257f425f55fe39fd6ac7a2354d693d</li>
+<li>Chris’s email to Swift Evolution: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20171113/041463.html</li>
+</ul>
+<p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 18 Dec 2017 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Introduce User-defined &quot;Dynamic Member Lookup&quot; Types:
+<ul>
+<li>First version: https://github.com/apple/swift-evolution/pull/768</li>
+<li>Second version: https://github.com/apple/swift-evolution/pull/774</li>
+</ul>
+</li>
+<li>Implementations:
+<ul>
+<li>First version: https://github.com/apple/swift/pull/13076</li>
+<li>Second version: https://github.com/apple/swift/pull/13361</li>
+</ul>
+</li>
+<li>Related &quot;dynamic callable&quot; proposal (gist in progress): https://gist.github.com/lattner/a6257f425f55fe39fd6ac7a2354d693d</li>
+<li>Chris’s email to Swift Evolution: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20171113/041463.html</li>
+</ul>
+<p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="20788733" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8a89de6b-42e8-4fde-b723-1d284960eb75/40-dynamic-number-lookup-proposal_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>40: Dynamic Member Lookup Proposal</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8a89de6b-42e8-4fde-b723-1d284960eb75/3000x3000/1513054038-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:21:35</itunes:duration>
+      <itunes:summary>We discuss Chris Lattner&apos;s recent &quot;Dynamic Member Lookup&quot; proposal.</itunes:summary>
+      <itunes:subtitle>We discuss Chris Lattner&apos;s recent &quot;Dynamic Member Lookup&quot; proposal.</itunes:subtitle>
+      <itunes:keywords>chris lattner, perl, python, swift, open source, json, swift-evolution, ruby, type safety, dynamic, google brain, interop</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>41</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">f05cc734-7091-46cd-9607-4ff8941d8bad</guid>
+      <title>39: Source Compatibility Suite Woes</title>
+      <description><![CDATA[<ul>
+<li>https://bugs.swift.org/browse/SR-4981</li>
+<li>https://github.com/apple/swift-source-compat-suite/blob/master/projects.json</li>
+<li>https://swift.org/source-compatibility</li>
+<li>Questions about expectations from swift source compatibility maintainers: https://github.com/apple/swift-source-compat-suite/pull/98</li>
+</ul>
+<p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 11 Dec 2017 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>https://bugs.swift.org/browse/SR-4981</li>
+<li>https://github.com/apple/swift-source-compat-suite/blob/master/projects.json</li>
+<li>https://swift.org/source-compatibility</li>
+<li>Questions about expectations from swift source compatibility maintainers: https://github.com/apple/swift-source-compat-suite/pull/98</li>
+</ul>
+<p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="25085608" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3e80f055-47d1-4a5f-a17c-46daae9e28fc/39-swift-source-compatibility-suite_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>39: Source Compatibility Suite Woes</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3e80f055-47d1-4a5f-a17c-46daae9e28fc/3000x3000/1512611494-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:26:03</itunes:duration>
+      <itunes:summary>The source compatibility suite has been useful in catching compatibility issues before official Swift releases are cut, but it leaves much to be desired especially around communication with project maintainers outside Apple.</itunes:summary>
+      <itunes:subtitle>The source compatibility suite has been useful in catching compatibility issues before official Swift releases are cut, but it leaves much to be desired especially around communication with project maintainers outside Apple.</itunes:subtitle>
+      <itunes:keywords>swift, continuous integration, programming, github, compatibility, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>40</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">1b871f76-97e4-4e8b-b30c-a4ac08fa7987</guid>
+      <title>38: Off to the Races</title>
+      <description><![CDATA[<ul>
+<li>Enable core dumps: <code>ulimit -c unlimited</code></li>
+<li>Mutating functions require exclusive access:
+<ul>
+<li>https://twitter.com/simjp/status/928714602937905153</li>
+<li>&quot;Calling a mutating method on a value type is a write access that lasts for the duration of the method.&quot;</li>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0176-enforce-exclusive-access-to-memory.md#proposed-solution</li>
+</ul>
+</li>
+<li>TSan with SwiftPM: https://twitter.com/simjp/status/929140877540278272</li>
+<li>Running TSan on CI: https://github.com/realm/SwiftLint/pull/1944</li>
+<li>WIP Adding first-party support for tsan to SwiftPM: https://github.com/apple/swift-package-manager/pull/1390</li>
+<li>SwiftPM Slack: https://swift-package-manager.herokuapp.com/</li>
+</ul>
+<p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 4 Dec 2017 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Enable core dumps: <code>ulimit -c unlimited</code></li>
+<li>Mutating functions require exclusive access:
+<ul>
+<li>https://twitter.com/simjp/status/928714602937905153</li>
+<li>&quot;Calling a mutating method on a value type is a write access that lasts for the duration of the method.&quot;</li>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0176-enforce-exclusive-access-to-memory.md#proposed-solution</li>
+</ul>
+</li>
+<li>TSan with SwiftPM: https://twitter.com/simjp/status/929140877540278272</li>
+<li>Running TSan on CI: https://github.com/realm/SwiftLint/pull/1944</li>
+<li>WIP Adding first-party support for tsan to SwiftPM: https://github.com/apple/swift-package-manager/pull/1390</li>
+<li>SwiftPM Slack: https://swift-package-manager.herokuapp.com/</li>
+</ul>
+<p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="22720383" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3b3a3df2-823c-44f1-a729-b71332353d91/38-data-bases-concurrency-threading_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>38: Off to the Races</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3b3a3df2-823c-44f1-a729-b71332353d91/3000x3000/1511997574-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:23:35</itunes:duration>
+      <itunes:summary>Think thread safety with Swift is the same as C languages, with slightly different syntax? Think again!</itunes:summary>
+      <itunes:subtitle>Think thread safety with Swift is the same as C languages, with slightly different syntax? Think again!</itunes:subtitle>
+      <itunes:keywords>mutating, swift package manager, core dumps, thread sanitizer, swift, swiftpm, slack, tsan, swift-evolution, ownership</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>39</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">277a5991-009e-4761-bdcb-2048bcddaf2c</guid>
+      <title>37: Enum Case Enumerable Proposal</title>
+      <description><![CDATA[<ul>
+<li>Original proposal: https://github.com/apple/swift-evolution/pull/114</li>
+<li>Latest email: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20171106/040950.html</li>
+<li>Reply: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20171106/040951.html</li>
+<li>Jordan Rose on over-abstraction: http://belkadan.com/blog/2017/09/Over-abstraction/</li>
+</ul>
+<p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 27 Nov 2017 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Original proposal: https://github.com/apple/swift-evolution/pull/114</li>
+<li>Latest email: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20171106/040950.html</li>
+<li>Reply: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20171106/040951.html</li>
+<li>Jordan Rose on over-abstraction: http://belkadan.com/blog/2017/09/Over-abstraction/</li>
+</ul>
+<p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="22068053" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0c2522ea-b3c8-4d72-a96b-653fdee6a484/37-enum-case-enumerable-proposal_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>37: Enum Case Enumerable Proposal</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0c2522ea-b3c8-4d72-a96b-653fdee6a484/3000x3000/1510274605-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:22:55</itunes:duration>
+      <itunes:summary>Enumerate. All. The. Cases.</itunes:summary>
+      <itunes:subtitle>Enumerate. All. The. Cases.</itunes:subtitle>
+      <itunes:keywords>cases, values, comparable, sourcery, protocols, enumerations, swift, open source, codable, swift-evolution, enums, over-abstraction, metaprogramming, range</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>38</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">7f2eb12b-296b-4638-946f-0ff33e14d091</guid>
+      <title>36: Swift Evolution - Current Topics &amp; Proposals</title>
+      <description><![CDATA[<ul>
+<li>Float80 Corrections: https://mobile.twitter.com/daniel_dunbar/status/923694549238611970</li>
+<li>Why the Swift Server Working Group's http library doesn't have an Xcode project: https://mobile.twitter.com/daniel_dunbar/status/923691076635914240</li>
+<li>SE-0186 Removing ownership keywords in protocols: https://github.com/apple/swift-evolution/blob/master/proposals/0186-remove-ownership-keyword-support-in-protocols.md</li>
+<li>Either/Result type
+<ul>
+<li>https://github.com/apple/swift-evolution/pull/757</li>
+<li>https://twitter.com/slava_pestov/status/925133908835835904</li>
+</ul>
+</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 13 Nov 2017 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Float80 Corrections: https://mobile.twitter.com/daniel_dunbar/status/923694549238611970</li>
+<li>Why the Swift Server Working Group's http library doesn't have an Xcode project: https://mobile.twitter.com/daniel_dunbar/status/923691076635914240</li>
+<li>SE-0186 Removing ownership keywords in protocols: https://github.com/apple/swift-evolution/blob/master/proposals/0186-remove-ownership-keyword-support-in-protocols.md</li>
+<li>Either/Result type
+<ul>
+<li>https://github.com/apple/swift-evolution/pull/757</li>
+<li>https://twitter.com/slava_pestov/status/925133908835835904</li>
+</ul>
+</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="19230976" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3ff00000-92a9-44e0-9f7a-f19dc57e3162/36-swift-evolution-topics_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>36: Swift Evolution - Current Topics &amp; Proposals</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3ff00000-92a9-44e0-9f7a-f19dc57e3162/3000x3000/1510263786-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:19:57</itunes:duration>
+      <itunes:summary>Brief discussion around some recent proposals.</itunes:summary>
+      <itunes:subtitle>Brief discussion around some recent proposals.</itunes:subtitle>
+      <itunes:keywords>swift-evolution, floating-point, either, server, swift, open source, float, programming, swift package manager, result, http</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>37</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">189ca593-d93d-47e4-aac2-c582c5fce79a</guid>
+      <title>35: Performance Profiling on Linux</title>
+      <description><![CDATA[<ul>
+<li>JP's FrenchKit talk on &quot;Performance Profiling Swift on Linux&quot;:
+<ul>
+<li>Video: https://youtu.be/TWeLLTFjqXg</li>
+<li>Slides: https://speakerdeck.com/jpsim/performance-profiling-swift-on-linux</li>
+</ul>
+</li>
+<li><a href="http://www.brendangregg.com/perf.html">Perf</a></li>
+<li><a href="http://valgrind.org/">Valgrind</a></li>
+<li><a href="http://valgrind.org/docs/manual/cl-manual.html">Callgrind</a></li>
+<li><a href="https://sourceware.org/binutils/docs/gprof/">GNU gprof</a></li>
+<li><a href="https://kcachegrind.github.io/html/Home.html">KCachegrind</a></li>
+<li><a href="https://github.com/brendangregg/FlameGraph">FlameGraph</a></li>
+<li><a href="https://github.com/jrfonseca/gprof2dot">gprof2dot</a></li>
+</ul>
+<p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 30 Oct 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>JP's FrenchKit talk on &quot;Performance Profiling Swift on Linux&quot;:
+<ul>
+<li>Video: https://youtu.be/TWeLLTFjqXg</li>
+<li>Slides: https://speakerdeck.com/jpsim/performance-profiling-swift-on-linux</li>
+</ul>
+</li>
+<li><a href="http://www.brendangregg.com/perf.html">Perf</a></li>
+<li><a href="http://valgrind.org/">Valgrind</a></li>
+<li><a href="http://valgrind.org/docs/manual/cl-manual.html">Callgrind</a></li>
+<li><a href="https://sourceware.org/binutils/docs/gprof/">GNU gprof</a></li>
+<li><a href="https://kcachegrind.github.io/html/Home.html">KCachegrind</a></li>
+<li><a href="https://github.com/brendangregg/FlameGraph">FlameGraph</a></li>
+<li><a href="https://github.com/jrfonseca/gprof2dot">gprof2dot</a></li>
+</ul>
+<p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="32007984" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/da4542a6-eb11-4838-b2e6-aec756244292/35-performance-profiling-on-linux_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>35: Performance Profiling on Linux</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/da4542a6-eb11-4838-b2e6-aec756244292/3000x3000/1508459481-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:33:16</itunes:duration>
+      <itunes:summary>How do you even profile without Instruments.app?</itunes:summary>
+      <itunes:subtitle>How do you even profile without Instruments.app?</itunes:subtitle>
+      <itunes:keywords>instruments, swift, callgrind, gprof2dot, performance, kcachegrind, flamegraph, frenchkit, qcachegrind, programming, cachegrind, perf, xcode, valgrind, perf tools</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>36</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">961d4d03-6f04-49d0-a035-c706a70fe128</guid>
+      <title>34: Floating-Point</title>
+      <description><![CDATA[<ul>
+<li>https://www.jessesquires.com/blog/floating-point-swift-ulp-and-epsilon/</li>
+<li>https://speakerdeck.com/jessesquires/exploring-swifts-numeric-types-and-protocols</li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0104-improved-integers.md">SE-0104: Protocol-oriented integers</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0113-rounding-functions-on-floatingpoint.md">SE-0113: Add integral rounding functions to FloatingPoint</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0067-floating-point-protocols.md">SE-0067: Enhanced Floating Point Protocols</a></li>
+</ul>
+<p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 23 Oct 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>https://www.jessesquires.com/blog/floating-point-swift-ulp-and-epsilon/</li>
+<li>https://speakerdeck.com/jessesquires/exploring-swifts-numeric-types-and-protocols</li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0104-improved-integers.md">SE-0104: Protocol-oriented integers</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0113-rounding-functions-on-floatingpoint.md">SE-0113: Add integral rounding functions to FloatingPoint</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0067-floating-point-protocols.md">SE-0067: Enhanced Floating Point Protocols</a></li>
+</ul>
+<p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="21278522" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f00dfd79-3a7e-46aa-9ac5-d0147cf8597e/34-floating-point_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>34: Floating-Point</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f00dfd79-3a7e-46aa-9ac5-d0147cf8597e/3000x3000/1508373199-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:22:05</itunes:duration>
+      <itunes:summary>We discuss Swift’s numeric protocols and types, especially those of the floating point variety.</itunes:summary>
+      <itunes:subtitle>We discuss Swift’s numeric protocols and types, especially those of the floating point variety.</itunes:subtitle>
+      <itunes:keywords>floating-point, protocols, swift, programming, ulp, epsilon, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>35</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">f1eef62a-9062-4fc8-a47d-44f0a9bb195c</guid>
+      <title>33: HTTP server v0.1.0</title>
+      <description><![CDATA[<ul>
+<li>Server APIs Project: https://swift.org/server-apis/</li>
+<li>Server APIs Working Group: https://swift.org/blog/server-api-workgroup/</li>
+<li>
+<h2>HTTP 0.1.0:</h2>
+<ul>
+<li>https://github.com/swift-server/http/releases/tag/0.1.0</li>
+<li>Docs: https://swift-server.github.io/http/</li>
+</ul>
+</li>
+<li>Namespacing discussion:
+<ul>
+<li>https://lists.swift.org/pipermail/swift-server-dev/Week-of-Mon-20170522/000466.html</li>
+<li>https://github.com/swift-server/http/pull/7</li>
+</ul>
+</li>
+<li>Can file issues on the repo, no JIRA</li>
+<li>Dedicated GitHub org: https://github.com/swift-server</li>
+<li>Which web framework is the fastest? https://github.com/swift-server/which_is_the_fastest</li>
+<li>Wraps a C HTTP parsing library from Node.js &amp; NGINX: https://github.com/swift-server/http/blob/0.1.0/Sources/CHTTPParser/http_parser.c#L1-L23</li>
+<li>Modular Swift Proposal: https://gist.github.com/CodaFi/cd66b7d70b5cd8e4e8b433fa2ace378a</li>
+</ul>
+<p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 16 Oct 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Server APIs Project: https://swift.org/server-apis/</li>
+<li>Server APIs Working Group: https://swift.org/blog/server-api-workgroup/</li>
+<li>
+<h2>HTTP 0.1.0:</h2>
+<ul>
+<li>https://github.com/swift-server/http/releases/tag/0.1.0</li>
+<li>Docs: https://swift-server.github.io/http/</li>
+</ul>
+</li>
+<li>Namespacing discussion:
+<ul>
+<li>https://lists.swift.org/pipermail/swift-server-dev/Week-of-Mon-20170522/000466.html</li>
+<li>https://github.com/swift-server/http/pull/7</li>
+</ul>
+</li>
+<li>Can file issues on the repo, no JIRA</li>
+<li>Dedicated GitHub org: https://github.com/swift-server</li>
+<li>Which web framework is the fastest? https://github.com/swift-server/which_is_the_fastest</li>
+<li>Wraps a C HTTP parsing library from Node.js &amp; NGINX: https://github.com/swift-server/http/blob/0.1.0/Sources/CHTTPParser/http_parser.c#L1-L23</li>
+<li>Modular Swift Proposal: https://gist.github.com/CodaFi/cd66b7d70b5cd8e4e8b433fa2ace378a</li>
+</ul>
+<p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="18088665" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b535714c-2b4b-4d7e-88d8-d0bb05e85431/33-http_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>33: HTTP server v0.1.0</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b535714c-2b4b-4d7e-88d8-d0bb05e85431/3000x3000/1507250175-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:18:46</itunes:duration>
+      <itunes:summary>We discuss the first release of the HTTP server library from the Swift Server APIs project.</itunes:summary>
+      <itunes:subtitle>We discuss the first release of the HTTP server library from the Swift Server APIs project.</itunes:subtitle>
+      <itunes:keywords>swift, http, namespacing, programming, nginx, ibm, server, nodejs, modules</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>34</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">64157dfb-9e18-4c29-9d61-c3b35229bd0a</guid>
+      <title>32: Migrating to Swift 4</title>
+      <description><![CDATA[<ul>
+<li>https://swift.org/migration-guide-swift4/</li>
+<li>Using two Swift Package Manager manifest files:
+<ul>
+<li>https://github.com/realm/SwiftLint/blob/0.23.0/Package.swift</li>
+<li>https://github.com/realm/SwiftLint/blob/0.23.0/Package%40swift-4.swift</li>
+</ul>
+</li>
+</ul>
+<p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 9 Oct 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>https://swift.org/migration-guide-swift4/</li>
+<li>Using two Swift Package Manager manifest files:
+<ul>
+<li>https://github.com/realm/SwiftLint/blob/0.23.0/Package.swift</li>
+<li>https://github.com/realm/SwiftLint/blob/0.23.0/Package%40swift-4.swift</li>
+</ul>
+</li>
+</ul>
+<p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="21464943" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7ba08528-4152-4f09-a9f3-22e7beb20dab/32-migratingtoswift4_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>32: Migrating to Swift 4</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7ba08528-4152-4f09-a9f3-22e7beb20dab/3000x3000/1507247637-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:22:17</itunes:duration>
+      <itunes:summary>Since many of you are probably migrating to Swift 4 as you listen to this, we figured we&apos;d share our thoughts on the transition.</itunes:summary>
+      <itunes:subtitle>Since many of you are probably migrating to Swift 4 as you listen to this, we figured we&apos;d share our thoughts on the transition.</itunes:subtitle>
+      <itunes:keywords>buddybuild, compiling, ios, swift, compile, migration, compilation, migrating, programming, swift package manager, swiftpm, swift4, xcode, swift3, objective-c</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>33</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">a0932647-ee15-4015-abb9-9aa05ab4e575</guid>
+      <title>31: Compile Times</title>
+      <description><![CDATA[<ul>
+<li>Measuring Swift compile times in Xcode 9: https://www.jessesquires.com/blog/measuring-compile-times-xcode9/</li>
+<li>Profiling your Swift compilation times: http://irace.me/swift-profiling</li>
+<li>Guarding Against Long Compiles: http://khanlou.com/2016/12/guarding-against-long-compiles/</li>
+<li>Type checker performance tests:
+<ul>
+<li>Directory: https://github.com/apple/swift/tree/master/validation-test/Sema/type_checker_perf</li>
+<li>PR: https://github.com/apple/swift/pull/11494</li>
+</ul>
+</li>
+<li>Mailing list discussions:
+<ul>
+<li>Ben Asher: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20161003/003099.html</li>
+<li>Mark Lacy: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20161003/003110.html</li>
+</ul>
+</li>
+</ul>
+<p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
+<p><strong>Thanks to <a href="https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped">BuddyBuild</a> for sponsoring this episode</strong>!</p>
+<p>If you're ready for free a continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams - give them a try at <a href="https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped">buddybuild.com</a> and let them know we sent you!</p>
+]]></description>
+      <pubDate>Mon, 2 Oct 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Measuring Swift compile times in Xcode 9: https://www.jessesquires.com/blog/measuring-compile-times-xcode9/</li>
+<li>Profiling your Swift compilation times: http://irace.me/swift-profiling</li>
+<li>Guarding Against Long Compiles: http://khanlou.com/2016/12/guarding-against-long-compiles/</li>
+<li>Type checker performance tests:
+<ul>
+<li>Directory: https://github.com/apple/swift/tree/master/validation-test/Sema/type_checker_perf</li>
+<li>PR: https://github.com/apple/swift/pull/11494</li>
+</ul>
+</li>
+<li>Mailing list discussions:
+<ul>
+<li>Ben Asher: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20161003/003099.html</li>
+<li>Mark Lacy: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20161003/003110.html</li>
+</ul>
+</li>
+</ul>
+<p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
+<p><strong>Thanks to <a href="https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped">BuddyBuild</a> for sponsoring this episode</strong>!</p>
+<p>If you're ready for free a continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams - give them a try at <a href="https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped">buddybuild.com</a> and let them know we sent you!</p>
+]]></content:encoded>
+      <enclosure length="24146990" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/319089de-aa5f-4d6c-892b-024e060eea48/31-compiletime_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>31: Compile Times</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/319089de-aa5f-4d6c-892b-024e060eea48/3000x3000/1506830929-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:25:05</itunes:duration>
+      <itunes:summary>We share our tips for measuring &amp; improving Swift compilation times, as well as share some news about recent efforts to test compile times within the Swift repo.</itunes:summary>
+      <itunes:subtitle>We share our tips for measuring &amp; improving Swift compilation times, as well as share some news about recent efforts to test compile times within the Swift repo.</itunes:subtitle>
+      <itunes:keywords>buddybuild, ios, compilation, swift, programming, compile, objective-c, xcode, compiling</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>32</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">d004be8a-fe39-4dbd-b202-f1e43c283649</guid>
+      <title>30: Weak References with Mike Ash</title>
+      <description><![CDATA[<p>Friday Q&amp;A:<br />
+https://mikeash.com/pyblog/friday-qa-2017-09-22-swift-4-weak-references.html</p>
+<p>Leave a review on iTunes:<br />
+https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2</p>
+<p>Chat with us at:<br />
+http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></description>
+      <pubDate>Mon, 25 Sep 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>Friday Q&amp;A:<br />
+https://mikeash.com/pyblog/friday-qa-2017-09-22-swift-4-weak-references.html</p>
+<p>Leave a review on iTunes:<br />
+https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2</p>
+<p>Chat with us at:<br />
+http://spectrum.chat/specfm/swift-unwrapped</p>
+]]></content:encoded>
+      <enclosure length="30301872" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/ce4dca05-3f4f-4c2d-8e41-8e5ded7eee7c/30-weak-references-mike-ash_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>30: Weak References with Mike Ash</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/ce4dca05-3f4f-4c2d-8e41-8e5ded7eee7c/3000x3000/1505949522-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:31:29</itunes:duration>
+      <itunes:summary>We welcome Mike Ash to the show to discuss the implementation details of weak references in Swift and how they&apos;ve changed.</itunes:summary>
+      <itunes:subtitle>We welcome Mike Ash to the show to discuss the implementation details of weak references in Swift and how they&apos;ve changed.</itunes:subtitle>
+      <itunes:keywords>strong, objective-c, swift, reference counting, memory management, release, weak references, retain, unowned, weak</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>31</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">51e146dc-2408-4a12-b924-59ec10b958ad</guid>
+      <title>29: Notes from Ted Kremenek, Recent Proposals &amp; Xcode 9 GM</title>
+      <description><![CDATA[<ul>
+<li>iPhone X keynote + GM seeds for Xcode 9, Swift 4</li>
+<li>Synthesizing Equatable and Hashable: https://github.com/apple/swift-evolution/blob/master/proposals/0185-synthesize-equatable-hashable.md</li>
+<li>Sourcery: https://github.com/krzysztofzablocki/Sourcery</li>
+<li>Improved pointers: https://github.com/apple/swift-evolution/blob/master/proposals/0184-unsafe-pointers-add-missing.md</li>
+<li>Notes from Ted Kremenek</li>
+<li>LibDispatch correction: https://twitter.com/pedantcoder/status/904951873483956225</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 18 Sep 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>iPhone X keynote + GM seeds for Xcode 9, Swift 4</li>
+<li>Synthesizing Equatable and Hashable: https://github.com/apple/swift-evolution/blob/master/proposals/0185-synthesize-equatable-hashable.md</li>
+<li>Sourcery: https://github.com/krzysztofzablocki/Sourcery</li>
+<li>Improved pointers: https://github.com/apple/swift-evolution/blob/master/proposals/0184-unsafe-pointers-add-missing.md</li>
+<li>Notes from Ted Kremenek</li>
+<li>LibDispatch correction: https://twitter.com/pedantcoder/status/904951873483956225</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="31753901" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d6039571-6970-4994-b8d9-75d73748aa26/29-technology_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>29: Notes from Ted Kremenek, Recent Proposals &amp; Xcode 9 GM</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d6039571-6970-4994-b8d9-75d73748aa26/3000x3000/1505695068-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:33:00</itunes:duration>
+      <itunes:summary>We discuss some recent Swift Evolution proposals, Xcode 9 GM, along with a boatload of Follow Up (tm) from Ted Kremenek and Pierre Habouzit.</itunes:summary>
+      <itunes:subtitle>We discuss some recent Swift Evolution proposals, Xcode 9 GM, along with a boatload of Follow Up (tm) from Ted Kremenek and Pierre Habouzit.</itunes:subtitle>
+      <itunes:keywords>ios, clang, sourcery, refactoring, swift, gcd, programming, equatable, swift4, hashable, xcode, pointers, libdispatch, xcode 9</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>30</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">925b5ed4-0dad-4225-b631-723431b3be5c</guid>
+      <title>28: Refactoring Engine</title>
+      <description><![CDATA[<ul>
+<li>Swift.org blog post on Swift Local Refactoring: https://swift.org/blog/swift-local-refactoring/</li>
+<li>Clang-based refactoring engine: http://lists.llvm.org/pipermail/cfe-dev/2017-June/054286.html</li>
+<li>Adding indexing support to Clangd: http://lists.llvm.org/pipermail/cfe-dev/2017-May/053869.html</li>
+<li>Small PR demonstrating implementing a refactoring action to simplify long number literal format:
+<ul>
+<li>https://github.com/apple/swift/pull/11711</li>
+<li>SR-5746: https://bugs.swift.org/browse/SR-5746</li>
+</ul>
+</li>
+<li>All Swift refactoring actions are defined in https://github.com/apple/swift/blob/master/include/swift/IDE/RefactoringKinds.def</li>
+<li>Ideas for potential refactoring transformations: https://bugs.swift.org/issues/?jql=labels%3DStarterProposal%20AND%20labels%3DRefactoring%20AND%20resolution%3DUnresolved</li>
+</ul>
+<p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
+<p>Thanks to BuddyBuild for sponsoring this episode: https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped</p>
+]]></description>
+      <pubDate>Mon, 11 Sep 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Swift.org blog post on Swift Local Refactoring: https://swift.org/blog/swift-local-refactoring/</li>
+<li>Clang-based refactoring engine: http://lists.llvm.org/pipermail/cfe-dev/2017-June/054286.html</li>
+<li>Adding indexing support to Clangd: http://lists.llvm.org/pipermail/cfe-dev/2017-May/053869.html</li>
+<li>Small PR demonstrating implementing a refactoring action to simplify long number literal format:
+<ul>
+<li>https://github.com/apple/swift/pull/11711</li>
+<li>SR-5746: https://bugs.swift.org/browse/SR-5746</li>
+</ul>
+</li>
+<li>All Swift refactoring actions are defined in https://github.com/apple/swift/blob/master/include/swift/IDE/RefactoringKinds.def</li>
+<li>Ideas for potential refactoring transformations: https://bugs.swift.org/issues/?jql=labels%3DStarterProposal%20AND%20labels%3DRefactoring%20AND%20resolution%3DUnresolved</li>
+</ul>
+<p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
+<p>Thanks to BuddyBuild for sponsoring this episode: https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped</p>
+]]></content:encoded>
+      <enclosure length="31734595" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/942f3e25-a7d6-4dbf-8b62-3326253070ba/28-refactoring-engine_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>28: Refactoring Engine</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/942f3e25-a7d6-4dbf-8b62-3326253070ba/3000x3000/1504986712-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:32:59</itunes:duration>
+      <itunes:summary>All about the recent refactoring pieces announced at WWDC 2017 and open sourced in the last few months.</itunes:summary>
+      <itunes:subtitle>All about the recent refactoring pieces announced at WWDC 2017 and open sourced in the last few months.</itunes:subtitle>
+      <itunes:keywords>buddybuild, ios, refactoring, swift, programming, clang, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>29</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">85305a46-c751-4869-9871-4a5847da1e08</guid>
+      <title>27: Concurrency with Chris Lattner</title>
+      <description><![CDATA[<p>Please take a minute to leave <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203">a review on iTunes</a> and <a href="http://spectrum.chat/specfm/swift-unwrapped">join us on Spectrum chat</a> if you'd like to discuss the show.</p>
+<ul>
+<li>
+<p>Concurrency manifesto: https://gist.github.com/lattner/31ed37682ef1576b16bca1432ea9f782</p>
+</li>
+<li>
+<p>Tweet from Chris: https://twitter.com/clattner_llvm/status/898310296183357441</p>
+</li>
+<li>
+<p>Ted Kremenek's email: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170814/038891.html</p>
+</li>
+<li>
+<p>Chris's email: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170814/038892.html</p>
+</li>
+<li>
+<p>Async/Await proposal: https://gist.github.com/lattner/429b9070918248274f25b714dcfc7619</p>
+</li>
+<li>
+<p>Async/Await prototype pull request: https://github.com/apple/swift/pull/11501</p>
+</li>
+<li>
+<p>Old doc on concurrency: https://github.com/apple/swift/blob/master/docs/proposals/Concurrency.rst</p>
+</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 4 Sep 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>Please take a minute to leave <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203">a review on iTunes</a> and <a href="http://spectrum.chat/specfm/swift-unwrapped">join us on Spectrum chat</a> if you'd like to discuss the show.</p>
+<ul>
+<li>
+<p>Concurrency manifesto: https://gist.github.com/lattner/31ed37682ef1576b16bca1432ea9f782</p>
+</li>
+<li>
+<p>Tweet from Chris: https://twitter.com/clattner_llvm/status/898310296183357441</p>
+</li>
+<li>
+<p>Ted Kremenek's email: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170814/038891.html</p>
+</li>
+<li>
+<p>Chris's email: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170814/038892.html</p>
+</li>
+<li>
+<p>Async/Await proposal: https://gist.github.com/lattner/429b9070918248274f25b714dcfc7619</p>
+</li>
+<li>
+<p>Async/Await prototype pull request: https://github.com/apple/swift/pull/11501</p>
+</li>
+<li>
+<p>Old doc on concurrency: https://github.com/apple/swift/blob/master/docs/proposals/Concurrency.rst</p>
+</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="57295173" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/af11f028-e749-46e7-915d-1a2d1529b939/27-chris-lattner_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>27: Concurrency with Chris Lattner</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/af11f028-e749-46e7-915d-1a2d1529b939/3000x3000/1503600803-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:59:36</itunes:duration>
+      <itunes:summary>We welcome Chris Lattner to the show to discuss concurrency in Swift 5 and beyond!</itunes:summary>
+      <itunes:subtitle>We welcome Chris Lattner to the show to discuss concurrency in Swift 5 and beyond!</itunes:subtitle>
+      <itunes:keywords>gcd, corelibs-dispatch, swift 5, concurrency, libdispatch, swift, async, threads, programming, tasks, chris lattner, actors, await</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>27</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">dae84d60-ca36-4389-8480-067620aa5406</guid>
+      <title>26: Swift 5 Goals</title>
+      <description><![CDATA[<ul>
+<li>Mailing List: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170807/038645.html</li>
+<li>Swift Evolution Readme: https://github.com/apple/swift-evolution/blob/master/README.md</li>
+</ul>
+<p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
+]]></description>
+      <pubDate>Mon, 28 Aug 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Mailing List: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170807/038645.html</li>
+<li>Swift Evolution Readme: https://github.com/apple/swift-evolution/blob/master/README.md</li>
+</ul>
+<p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
+]]></content:encoded>
+      <enclosure length="33417241" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b307fe79-65a0-4293-a524-d0e5e89d123c/26-swift5_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>26: Swift 5 Goals</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b307fe79-65a0-4293-a524-d0e5e89d123c/3000x3000/1503600908-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:34:44</itunes:duration>
+      <itunes:summary>We share our thoughts on the newly announced goals for Swift 5.</itunes:summary>
+      <itunes:subtitle>We share our thoughts on the newly announced goals for Swift 5.</itunes:subtitle>
+      <itunes:keywords>application binary interface, swift, open source, abi stability, swift 5, memory ownership, programming, compiler</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>28</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">308a542c-b404-47b5-a4ec-7d378e40b0bd</guid>
+      <title>25: ABI Stability –  Calling Convention, Runtime and Standard Library</title>
+      <description><![CDATA[<ul>
+<li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
+<li>ABI Dashboard: https://swift.org/abi-stability</li>
+<li>ABI Docs: https://github.com/apple/swift/tree/master/docs/ABI</li>
+</ul>
+<p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
+]]></description>
+      <pubDate>Mon, 21 Aug 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
+<li>ABI Dashboard: https://swift.org/abi-stability</li>
+<li>ABI Docs: https://github.com/apple/swift/tree/master/docs/ABI</li>
+</ul>
+<p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
+]]></content:encoded>
+      <enclosure length="25114944" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5b31a287-ea14-436c-8d8d-4516731b2661/25-abi-stability-calling-convention-runtime-and-standard-library_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>25: ABI Stability –  Calling Convention, Runtime and Standard Library</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5b31a287-ea14-436c-8d8d-4516731b2661/3000x3000/1502834005-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:26:05</itunes:duration>
+      <itunes:summary>The fourth and final episode in our series on ABI Stability, we cover the remaining categories of decisions that must be made to stabilize the ABI.</itunes:summary>
+      <itunes:subtitle>The fourth and final episode in our series on ABI Stability, we cover the remaining categories of decisions that must be made to stabilize the ABI.</itunes:subtitle>
+      <itunes:keywords>runtime, swift, abi, stdlib, programming, application binary interface</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>26</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">d5bee65a-3d2e-4fbc-a6e9-ab89fb0a4be4</guid>
+      <title>24: ABI Stability - Mangling</title>
+      <description><![CDATA[<ul>
+<li>Twitter thread on source stability discussion for episode 22: https://twitter.com/swift_unwrapped/status/892023116377075712</li>
+<li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
+<li>ABI Dashboard: https://swift.org/abi-stability</li>
+<li>ABI Docs: https://github.com/apple/swift/tree/master/docs/ABI</li>
+<li>Mike Ash &amp; Gwynne Raskind Friday Q&amp;A 2014-08-08: Swift Name Mangling: https://mikeash.com/pyblog/friday-qa-2014-08-15-swift-name-mangling.html</li>
+</ul>
+<p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
+]]></description>
+      <pubDate>Mon, 14 Aug 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Twitter thread on source stability discussion for episode 22: https://twitter.com/swift_unwrapped/status/892023116377075712</li>
+<li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
+<li>ABI Dashboard: https://swift.org/abi-stability</li>
+<li>ABI Docs: https://github.com/apple/swift/tree/master/docs/ABI</li>
+<li>Mike Ash &amp; Gwynne Raskind Friday Q&amp;A 2014-08-08: Swift Name Mangling: https://mikeash.com/pyblog/friday-qa-2014-08-15-swift-name-mangling.html</li>
+</ul>
+<p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
+]]></content:encoded>
+      <enclosure length="32570478" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/bdc44b4f-6b68-4c2f-bfed-a61b1b8dfc93/24-abi-stability-mangling_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>24: ABI Stability - Mangling</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/bdc44b4f-6b68-4c2f-bfed-a61b1b8dfc93/3000x3000/1502323486-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:33:51</itunes:duration>
+      <itunes:summary>Continuing our series on ABI Stability with a third installment, we focus on the mangling component and address some past mistakes.</itunes:summary>
+      <itunes:subtitle>Continuing our series on ABI Stability with a third installment, we focus on the mangling component and address some past mistakes.</itunes:subtitle>
+      <itunes:keywords>name mangling, swift, programming, application binary interface, abi</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>25</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">b3439e79-ec13-45e8-b054-26c82e7f76bd</guid>
+      <title>23: ABI Stability – Data Layout and Metadata</title>
+      <description><![CDATA[<ul>
+<li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
+<li>ABI Dashboard: https://swift.org/abi-stability</li>
+<li>ABI Docs: https://github.com/apple/swift/tree/master/docs/ABI</li>
+</ul>
+<p>Swift memory layout (Mike Ash):</p>
+<ul>
+<li>Talk: https://news.realm.io/news/goto-mike-ash-exploring-swift-memory-layout/</li>
+<li>Part 1: https://mikeash.com/pyblog/friday-qa-2014-07-18-exploring-swift-memory-layout.html</li>
+<li>Part 2: https://www.mikeash.com/pyblog/friday-qa-2014-08-01-exploring-swift-memory-layout-part-ii.html</li>
+</ul>
+<p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped">Buddy Build</a>: a continuous integration, continuous deployment and user feedback platform built specifically for mobile development teams. Try it out today FREE: https://www.buddybuild.com</p>
+]]></description>
+      <pubDate>Mon, 7 Aug 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
+<li>ABI Dashboard: https://swift.org/abi-stability</li>
+<li>ABI Docs: https://github.com/apple/swift/tree/master/docs/ABI</li>
+</ul>
+<p>Swift memory layout (Mike Ash):</p>
+<ul>
+<li>Talk: https://news.realm.io/news/goto-mike-ash-exploring-swift-memory-layout/</li>
+<li>Part 1: https://mikeash.com/pyblog/friday-qa-2014-07-18-exploring-swift-memory-layout.html</li>
+<li>Part 2: https://www.mikeash.com/pyblog/friday-qa-2014-08-01-exploring-swift-memory-layout-part-ii.html</li>
+</ul>
+<p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped">Buddy Build</a>: a continuous integration, continuous deployment and user feedback platform built specifically for mobile development teams. Try it out today FREE: https://www.buddybuild.com</p>
+]]></content:encoded>
+      <enclosure length="36135284" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/64f4054e-fe7f-407a-90e9-54c1b42afa65/23-abi-data-layout_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>23: ABI Stability – Data Layout and Metadata</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/64f4054e-fe7f-407a-90e9-54c1b42afa65/3000x3000/1501891793-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:37:34</itunes:duration>
+      <itunes:summary>Following last week&apos;s episode on the big picture of ABI Stability, we focus on two categories of decisions that need to happen to get there: data layout and metadata.</itunes:summary>
+      <itunes:subtitle>Following last week&apos;s episode on the big picture of ABI Stability, we focus on two categories of decisions that need to happen to get there: data layout and metadata.</itunes:subtitle>
+      <itunes:keywords>swift, abi, programming, application binary interface</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>24</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">9598e3fb-49fc-49dc-affc-8c4828065544</guid>
+      <title>22: ABI Stability – The Big Picture</title>
+      <description><![CDATA[<ul>
+<li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
+<li>ABI Dashboard: https://swift.org/abi-stability</li>
+<li>ABI Docs: https://github.com/apple/swift/blob/master/docs/ABI.rst</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 31 Jul 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
+<li>ABI Dashboard: https://swift.org/abi-stability</li>
+<li>ABI Docs: https://github.com/apple/swift/blob/master/docs/ABI.rst</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="36902185" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/96281bdf-d8a7-42b6-adc1-4d6cdc3ad58a/22-abi-stability_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>22: ABI Stability – The Big Picture</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/96281bdf-d8a7-42b6-adc1-4d6cdc3ad58a/3000x3000/1501362145-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:38:22</itunes:duration>
+      <itunes:summary>We clear up some of the misconceptions around what ABI stability means, how we&apos;ll get there and why it&apos;s important.</itunes:summary>
+      <itunes:subtitle>We clear up some of the misconceptions around what ABI stability means, how we&apos;ll get there and why it&apos;s important.</itunes:subtitle>
+      <itunes:keywords>swift, programming, application binary interface, abi</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>23</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">ae1000e0-0ecf-4a3b-ae19-6f54f43a8fc6</guid>
+      <title>21: New Proposals</title>
+      <description><![CDATA[<ul>
+<li>Bug of the week (sandboxing!): <a href="https://bugs.swift.org/browse/SR-5491">SR-549</a>, <a href="https://bugs.swift.org/browse/SR-5061">SR-5061</a></li>
+<li>String newline escaping: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0182-newline-escape-in-strings.md">SE-0182</a></li>
+<li>Substring perf: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0183-substring-affordances.md">SE-0183</a></li>
+<li>String index overhaul: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0180-string-index-overhaul.md">SE-0180</a></li>
+<li>SPM c++ support: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0181-package-manager-cpp-language-version.md">SE-0181</a></li>
+</ul>
+]]></description>
+      <pubDate>Mon, 24 Jul 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Bug of the week (sandboxing!): <a href="https://bugs.swift.org/browse/SR-5491">SR-549</a>, <a href="https://bugs.swift.org/browse/SR-5061">SR-5061</a></li>
+<li>String newline escaping: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0182-newline-escape-in-strings.md">SE-0182</a></li>
+<li>Substring perf: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0183-substring-affordances.md">SE-0183</a></li>
+<li>String index overhaul: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0180-string-index-overhaul.md">SE-0180</a></li>
+<li>SPM c++ support: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0181-package-manager-cpp-language-version.md">SE-0181</a></li>
+</ul>
+]]></content:encoded>
+      <enclosure length="26235023" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0420d3d2-6780-4313-a5b2-a77b6732d4eb/21-newproposals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>21: New Proposals</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0420d3d2-6780-4313-a5b2-a77b6732d4eb/3000x3000/1500760748-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:27:15</itunes:duration>
+      <itunes:summary>This week we dive into some of the recent proposals, including SE-0180, SE-0181, SE-0182, SE-0183</itunes:summary>
+      <itunes:subtitle>This week we dive into some of the recent proposals, including SE-0180, SE-0181, SE-0182, SE-0183</itunes:subtitle>
+      <itunes:keywords>se-0182, se-0181, swift, open source, swift package manager, c++, se-0180, se-0183, swift-evolution, strings</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>22</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">969650cb-762a-43c5-8b17-c69308bf0084</guid>
+      <title>20: Swift Migrator</title>
+      <description><![CDATA[<ul>
+<li>Bug of the week: https://bugs.swift.org/browse/SR-4088</li>
+<li>Ted’s email: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20170605/004751.html</li>
+<li>Migrator: https://github.com/apple/swift/tree/master/lib/Migrator</li>
+<li>Migrating to Swift 4: https://swift.org/migration-guide/, https://help.apple.com/xcode/mac/current/#/deve838b19a1</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 17 Jul 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Bug of the week: https://bugs.swift.org/browse/SR-4088</li>
+<li>Ted’s email: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20170605/004751.html</li>
+<li>Migrator: https://github.com/apple/swift/tree/master/lib/Migrator</li>
+<li>Migrating to Swift 4: https://swift.org/migration-guide/, https://help.apple.com/xcode/mac/current/#/deve838b19a1</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="28326384" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/6bd2a1e4-241b-40fb-9bb2-c3c5fe470fb3/20-swift-migrator_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>20: Swift Migrator</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/6bd2a1e4-241b-40fb-9bb2-c3c5fe470fb3/3000x3000/1499980181-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:29:26</itunes:duration>
+      <itunes:summary>We dissect the newly open sourced part of Swift tooling that helps us port our apps to the latest Swift version.</itunes:summary>
+      <itunes:subtitle>We dissect the newly open sourced part of Swift tooling that helps us port our apps to the latest Swift version.</itunes:subtitle>
+      <itunes:keywords>refactoring, swift, open source, migrator, wwdc, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>21</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">fba67fdb-e2fb-4272-8fb5-49dde817613d</guid>
+      <title>19: WWDC Reactions</title>
+      <description><![CDATA[<ul>
+<li>Improvement of the week: https://github.com/apple/swift-package-manager/pull/1249</li>
+<li>Ted’s email: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20170605/004751.html</li>
+<li>Panel: https://news.realm.io/news/wwdc-2017-swift-panel/</li>
+<li>Xcode 9b2 release notes: http://adcdownload.apple.com/Developer_Tools/Xcode_9_beta_2/Release_Notes_for_Xcode_9_beta_2.pdf</li>
+<li>Ole Begemman’s panel highlights: https://oleb.net/blog/2017/06/chris-lattner-wwdc-swift-panel/</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 10 Jul 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Improvement of the week: https://github.com/apple/swift-package-manager/pull/1249</li>
+<li>Ted’s email: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20170605/004751.html</li>
+<li>Panel: https://news.realm.io/news/wwdc-2017-swift-panel/</li>
+<li>Xcode 9b2 release notes: http://adcdownload.apple.com/Developer_Tools/Xcode_9_beta_2/Release_Notes_for_Xcode_9_beta_2.pdf</li>
+<li>Ole Begemman’s panel highlights: https://oleb.net/blog/2017/06/chris-lattner-wwdc-swift-panel/</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="30979470" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0cc3b9b4-fe77-4261-8b07-7121aa70d8fa/22_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>19: WWDC Reactions</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0cc3b9b4-fe77-4261-8b07-7121aa70d8fa/3000x3000/1499630397-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:42:56</itunes:duration>
+      <itunes:summary>A month after WWDC, we share our thoughts on the announcements and events from the week.</itunes:summary>
+      <itunes:subtitle>A month after WWDC, we share our thoughts on the announcements and events from the week.</itunes:subtitle>
+      <itunes:keywords>performance, refactoring, swift, open source, realm, ted kremenek, migrator, wwdc, xcode, chris lattner</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>20</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">951f1d5e-abfb-439a-9443-e0009ec215b7</guid>
+      <title>18: Community Open Source Spotlight</title>
+      <description><![CDATA[<ul>
+<li>SipHash: https://github.com/lorentey/SipHash</li>
+<li>CryptoSwift: https://github.com/krzyzanowskim/CryptoSwift</li>
+<li>Result: https://github.com/antitypical/Result</li>
+<li>Commander: https://github.com/kylef/Commander</li>
+<li>SwiftyGPIO: https://github.com/uraimo/SwiftyGPIO</li>
+<li>Stencil: https://github.com/kylef/Stencil</li>
+<li>Sourcery: https://github.com/krzysztofzablocki/Sourcery</li>
+<li>SWXMLHash: https://github.com/drmohundro/SWXMLHash</li>
+<li>YamlSwift: https://github.com/behrang/YamlSwift</li>
+<li>Yams: https://github.com/jpsim/Yams</li>
+<li>swift-lsp (in progress): https://github.com/owensd/swift-lsp</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 3 Jul 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>SipHash: https://github.com/lorentey/SipHash</li>
+<li>CryptoSwift: https://github.com/krzyzanowskim/CryptoSwift</li>
+<li>Result: https://github.com/antitypical/Result</li>
+<li>Commander: https://github.com/kylef/Commander</li>
+<li>SwiftyGPIO: https://github.com/uraimo/SwiftyGPIO</li>
+<li>Stencil: https://github.com/kylef/Stencil</li>
+<li>Sourcery: https://github.com/krzysztofzablocki/Sourcery</li>
+<li>SWXMLHash: https://github.com/drmohundro/SWXMLHash</li>
+<li>YamlSwift: https://github.com/behrang/YamlSwift</li>
+<li>Yams: https://github.com/jpsim/Yams</li>
+<li>swift-lsp (in progress): https://github.com/owensd/swift-lsp</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="36266469" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4e4a91d7-9e9c-45be-b4fd-cd1a76ee9d6e/18-oss-spotlight_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>18: Community Open Source Spotlight</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4e4a91d7-9e9c-45be-b4fd-cd1a76ee9d6e/3000x3000/1496791930-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:37:42</itunes:duration>
+      <itunes:summary>Taking a break from Swift itself, we shine the spotlight on the open source community and highlight some lesser-known open source Swift projects that we think are interesting!</itunes:summary>
+      <itunes:subtitle>Taking a break from Swift itself, we shine the spotlight on the open source community and highlight some lesser-known open source Swift projects that we think are interesting!</itunes:subtitle>
+      <itunes:keywords>swift, open source, cocoapods, objective-c, carthage, programming, github, swift package manager, swift-evolution</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>19</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">986428b8-f605-4d10-b75a-d73a34aaee45</guid>
+      <title>17: Testing Swift</title>
+      <description><![CDATA[<ul>
+<li>Testing Swift: https://github.com/apple/swift/blob/master/docs/Testing.rst</li>
+<li>Lit: LLVM Integrated Tester: http://llvm.org/docs/CommandGuide/lit.html</li>
+<li>SwiftCI:
+<ul>
+<li>https://ci.swift.org</li>
+<li>Announcement: https://swift.org/blog/swift-ci/</li>
+<li>Overview: https://swift.org/continuous-integration/</li>
+<li>Docs: https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md</li>
+</ul>
+</li>
+<li>Source Compatibility: https://github.com/apple/swift-source-compat-suite</li>
+<li>Smoke Testing</li>
+<li>Validation Testing</li>
+<li>Benchmarking</li>
+<li>Lint Testing</li>
+<li>Source Compatibility Testing</li>
+<li>Testing SIL</li>
+<li>Swift compile time measurement: http://irace.me/swift-profiling/</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="http://buddybuild.com">Buddy Build</a>: A continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams. Try it out today FREE: http://buddybuild.com</p>
+]]></description>
+      <pubDate>Mon, 26 Jun 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Testing Swift: https://github.com/apple/swift/blob/master/docs/Testing.rst</li>
+<li>Lit: LLVM Integrated Tester: http://llvm.org/docs/CommandGuide/lit.html</li>
+<li>SwiftCI:
+<ul>
+<li>https://ci.swift.org</li>
+<li>Announcement: https://swift.org/blog/swift-ci/</li>
+<li>Overview: https://swift.org/continuous-integration/</li>
+<li>Docs: https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md</li>
+</ul>
+</li>
+<li>Source Compatibility: https://github.com/apple/swift-source-compat-suite</li>
+<li>Smoke Testing</li>
+<li>Validation Testing</li>
+<li>Benchmarking</li>
+<li>Lint Testing</li>
+<li>Source Compatibility Testing</li>
+<li>Testing SIL</li>
+<li>Swift compile time measurement: http://irace.me/swift-profiling/</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="http://buddybuild.com">Buddy Build</a>: A continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams. Try it out today FREE: http://buddybuild.com</p>
+]]></content:encoded>
+      <enclosure length="29883396" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4fddc14c-1844-486b-a289-d1162f2e176f/17-swift-testing_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>17: Testing Swift</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4fddc14c-1844-486b-a289-d1162f2e176f/3000x3000/1495497709-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:31:03</itunes:duration>
+      <itunes:summary>Exploring the many different ways in which the Swift compiler is tested.</itunes:summary>
+      <itunes:subtitle>Exploring the many different ways in which the Swift compiler is tested.</itunes:subtitle>
+      <itunes:keywords>sil, bdd, llvm, swift, compilers, lit, programming, objective-c, testing, swift-evolution, tdd, continuous integration, swift package manager, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>15</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">6b64ce9a-1275-47e5-a8b1-64e2b916149d</guid>
+      <title>16: Error Handling in Swift — A History</title>
+      <description><![CDATA[<ul>
+<li>Error Handling: https://github.com/apple/swift/blob/master/docs/ErrorHandling.rst</li>
+<li>Rationale and Proposal: https://github.com/apple/swift/blob/master/docs/ErrorHandlingRationale.rst</li>
+<li>Swift 2.0 blog post: https://developer.apple.com/swift/blog/?id=29</li>
+<li>Cocoa error handling: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/ErrorHandling/ErrorHandling.html</li>
+<li>Typed <code>throws</code> vs not discussed in Swift Weekly Brief <a href="https://swiftweekly.github.io/issue-68/">#68</a> and <a href="https://swiftweekly.github.io/issue-51/">#51</a></li>
+</ul>
+]]></description>
+      <pubDate>Mon, 19 Jun 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Error Handling: https://github.com/apple/swift/blob/master/docs/ErrorHandling.rst</li>
+<li>Rationale and Proposal: https://github.com/apple/swift/blob/master/docs/ErrorHandlingRationale.rst</li>
+<li>Swift 2.0 blog post: https://developer.apple.com/swift/blog/?id=29</li>
+<li>Cocoa error handling: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/ErrorHandling/ErrorHandling.html</li>
+<li>Typed <code>throws</code> vs not discussed in Swift Weekly Brief <a href="https://swiftweekly.github.io/issue-68/">#68</a> and <a href="https://swiftweekly.github.io/issue-51/">#51</a></li>
+</ul>
+]]></content:encoded>
+      <enclosure length="34711245" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3c876c5d-2686-4b2c-94c0-b722f643dbcb/16-error-handling_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>16: Error Handling in Swift — A History</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3c876c5d-2686-4b2c-94c0-b722f643dbcb/3000x3000/1496791789-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:36:05</itunes:duration>
+      <itunes:summary>The state of error handling in Swift and a brief history on how we got here, as well as comparisons to Objective-C.</itunes:summary>
+      <itunes:subtitle>The state of error handling in Swift and a brief history on how we got here, as well as comparisons to Objective-C.</itunes:subtitle>
+      <itunes:keywords>swift, compilers, error handling, programming, objective-c, swift-evolution</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>18</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">c7ae8e06-b354-4bf2-bbab-846294a52ac9</guid>
+      <title>15: What&apos;s New in Swift 4 (Part 2)</title>
+      <description><![CDATA[<h3>What should you expect with Swift 4?</h3>
+<p>Some great new features and improvements.</p>
+<ul>
+<li>Ole's Swift 4 playground: https://oleb.net/blog/2017/05/whats-new-in-swift-4-playground/</li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0165-dict.md">Swift Evolution Proposal SE-0165: Dictionary and Set Enhancements</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0173-swap-indices.md">Swift Evolution Proposal SE-0173: Add <code>MutableCollection.swapAt(_:_:)</code></a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0176-enforce-exclusive-access-to-memory.md">Swift Evolution Proposal SE-0176: Enforce Exclusive Access to Memory</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0171-reduce-with-inout.md">Swift Evolution Proposal SE-0171: Reduce with <code>inout</code></a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0148-generic-subscripts.md">Swift Evolution Proposal SE-0148: Generic Subscripts</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0170-nsnumber_bridge.md">Swift Evolution Proposal SE-0170: NSNumber bridging and Numeric types</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md">Swift Evolution Proposal SE-0156: Class and Subtype existentials</a></li>
+</ul>
+]]></description>
+      <pubDate>Mon, 12 Jun 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h3>What should you expect with Swift 4?</h3>
+<p>Some great new features and improvements.</p>
+<ul>
+<li>Ole's Swift 4 playground: https://oleb.net/blog/2017/05/whats-new-in-swift-4-playground/</li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0165-dict.md">Swift Evolution Proposal SE-0165: Dictionary and Set Enhancements</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0173-swap-indices.md">Swift Evolution Proposal SE-0173: Add <code>MutableCollection.swapAt(_:_:)</code></a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0176-enforce-exclusive-access-to-memory.md">Swift Evolution Proposal SE-0176: Enforce Exclusive Access to Memory</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0171-reduce-with-inout.md">Swift Evolution Proposal SE-0171: Reduce with <code>inout</code></a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0148-generic-subscripts.md">Swift Evolution Proposal SE-0148: Generic Subscripts</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0170-nsnumber_bridge.md">Swift Evolution Proposal SE-0170: NSNumber bridging and Numeric types</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md">Swift Evolution Proposal SE-0156: Class and Subtype existentials</a></li>
+</ul>
+]]></content:encoded>
+      <enclosure length="29425349" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/401a9081-0886-4643-a347-2f2a20f6b384/16-what-is-new-with-swift-4-part-2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>15: What&apos;s New in Swift 4 (Part 2)</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/401a9081-0886-4643-a347-2f2a20f6b384/3000x3000/1496116554-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:30:35</itunes:duration>
+      <itunes:summary>Part two of our discussion on the new features and improvements in Swift 4! There were so many great things to discuss, we needed two episodes!</itunes:summary>
+      <itunes:subtitle>Part two of our discussion on the new features and improvements in Swift 4! There were so many great things to discuss, we needed two episodes!</itunes:subtitle>
+      <itunes:keywords>swift-evolution, refactoring, swift, objective-c, swift package manager, programming, wwdc, xcode, playgrounds</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>17</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">fae2d1e4-6ed0-4177-8b2d-5d5b6ba3edb0</guid>
+      <title>14: What&apos;s New in Swift 4 (Part 1)</title>
+      <description><![CDATA[<h3>What should you expect with Swift 4?</h3>
+<p>Some great new features and improvements.</p>
+<ul>
+<li>Ole's Swift 4 playground: https://oleb.net/blog/2017/05/whats-new-in-swift-4-playground/</li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0172-one-sided-ranges.md">Swift Evolution Proposal SE-0172: One-sided Ranges</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0168-multi-line-string-literals.md">Swift Evolution Proposal SE-0168: Multi-Line String Literals</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0163-string-revision-1.md">Swift Evolution Proposal SE-0163: String Revision: Collection Conformance, C Interop, Transcoding</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0178-character-unicode-view.md">Swift Evolution Proposal SE-0178: Add <code>unicodeScalars</code> property to <code>Character</code></a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0169-improve-interaction-between-private-declarations-and-extensions.md">Swift Evolution Proposal SE-0169: Improve Interaction Between private Declarations and Extensions</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0161-key-paths.md">Swift Evolution Proposal SE-0161: Smart KeyPaths: Better Key-Value Coding for Swift</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0166-swift-archival-serialization.md">Swift Evolution Proposal SE-0166: Swift Archival &amp; Serialization</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0167-swift-encoders.md">Swift Evolution Proposal SE-0167: Swift Encoders</a></li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="http://buddybuild.com">Buddy Build</a>: A continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams.</p>
+]]></description>
+      <pubDate>Mon, 5 Jun 2017 12:52:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h3>What should you expect with Swift 4?</h3>
+<p>Some great new features and improvements.</p>
+<ul>
+<li>Ole's Swift 4 playground: https://oleb.net/blog/2017/05/whats-new-in-swift-4-playground/</li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0172-one-sided-ranges.md">Swift Evolution Proposal SE-0172: One-sided Ranges</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0168-multi-line-string-literals.md">Swift Evolution Proposal SE-0168: Multi-Line String Literals</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0163-string-revision-1.md">Swift Evolution Proposal SE-0163: String Revision: Collection Conformance, C Interop, Transcoding</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0178-character-unicode-view.md">Swift Evolution Proposal SE-0178: Add <code>unicodeScalars</code> property to <code>Character</code></a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0169-improve-interaction-between-private-declarations-and-extensions.md">Swift Evolution Proposal SE-0169: Improve Interaction Between private Declarations and Extensions</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0161-key-paths.md">Swift Evolution Proposal SE-0161: Smart KeyPaths: Better Key-Value Coding for Swift</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0166-swift-archival-serialization.md">Swift Evolution Proposal SE-0166: Swift Archival &amp; Serialization</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0167-swift-encoders.md">Swift Evolution Proposal SE-0167: Swift Encoders</a></li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="http://buddybuild.com">Buddy Build</a>: A continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams.</p>
+]]></content:encoded>
+      <enclosure length="25065199" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/c73ea98e-f98e-4448-8bf2-67adcf036bca/14-what-is-new-with-swift-4-part-1_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>14: What&apos;s New in Swift 4 (Part 1)</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/c73ea98e-f98e-4448-8bf2-67adcf036bca/3000x3000/1496116453-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:26:02</itunes:duration>
+      <itunes:summary>We discuss some of the new features and improvements in Swift 4!</itunes:summary>
+      <itunes:subtitle>We discuss some of the new features and improvements in Swift 4!</itunes:subtitle>
+      <itunes:keywords>objective-c, refactoring, swift, programming, wwdc, swift package manager, xcode, playgrounds, swift-evolution</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>16</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">148571bd-cb37-45e7-8faf-726d0970554a</guid>
+      <title>13: WWDC Predictions</title>
+      <description><![CDATA[<ul>
+<li>SwiftPM iOS
+<ul>
+<li>SwiftPM Cross-Compilation: https://github.com/apple/swift-package-manager/pull/1098</li>
+</ul>
+</li>
+<li>SwiftPM Xcode
+<ul>
+<li>Better SwiftPM/Xcode integration: https://twitter.com/SmileyKeith/status/862444840008548352</li>
+<li>Potential Package.swift support in Xcode</li>
+</ul>
+</li>
+<li>Swift Refactoring in Xcode
+<ul>
+<li>References to &quot;Rename&quot; actions in SourceKit from Xcode 8.3 https://twitter.com/simjp/status/848288462952316928</li>
+<li>Swift Syntax Structured Editing Library: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20170206/004066.html</li>
+</ul>
+</li>
+<li>Improvements to Swift Playgrounds on iPad</li>
+<li>Likely improvements to Xcode Source Extensions (refactoring extensions?)</li>
+<li>We’re in a quiet period leading up to WWDC</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="https://kobiton.com/swiftunwrapped">Kobiton</a>: complete mobile device lab solution.</p>
+<p>Start a 15 day free trial today at https://kobiton.com/swiftunwrapped.</p>
+]]></description>
+      <pubDate>Mon, 29 May 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>SwiftPM iOS
+<ul>
+<li>SwiftPM Cross-Compilation: https://github.com/apple/swift-package-manager/pull/1098</li>
+</ul>
+</li>
+<li>SwiftPM Xcode
+<ul>
+<li>Better SwiftPM/Xcode integration: https://twitter.com/SmileyKeith/status/862444840008548352</li>
+<li>Potential Package.swift support in Xcode</li>
+</ul>
+</li>
+<li>Swift Refactoring in Xcode
+<ul>
+<li>References to &quot;Rename&quot; actions in SourceKit from Xcode 8.3 https://twitter.com/simjp/status/848288462952316928</li>
+<li>Swift Syntax Structured Editing Library: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20170206/004066.html</li>
+</ul>
+</li>
+<li>Improvements to Swift Playgrounds on iPad</li>
+<li>Likely improvements to Xcode Source Extensions (refactoring extensions?)</li>
+<li>We’re in a quiet period leading up to WWDC</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="https://kobiton.com/swiftunwrapped">Kobiton</a>: complete mobile device lab solution.</p>
+<p>Start a 15 day free trial today at https://kobiton.com/swiftunwrapped.</p>
+]]></content:encoded>
+      <enclosure length="26505038" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b678161c-f1c3-48f9-bc6f-da9aff44f2b4/13-wwdcpredictions_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>13: WWDC Predictions</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b678161c-f1c3-48f9-bc6f-da9aff44f2b4/3000x3000/1495489380-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:27:32</itunes:duration>
+      <itunes:summary>We share our hopes &amp; expectations for the Swift language at WWDC 2017.</itunes:summary>
+      <itunes:subtitle>We share our hopes &amp; expectations for the Swift language at WWDC 2017.</itunes:subtitle>
+      <itunes:keywords>objective-c, ipad, refactoring, swift, programming, playgrounds, wwdc, swift package manager, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>14</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">05f8c8cd-d19a-4456-bb14-ff6ba5200a34</guid>
+      <title>12: Swift Evolution</title>
+      <description><![CDATA[<ul>
+<li>Moving to Discourse, email from Ted: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170206/031657.html</li>
+<li>Nate Cook's Discourse experiment: http://discourse.natecook.com/</li>
+<li>Slava tweets:
+<ul>
+<li>https://twitter.com/slava_pestov/status/854490613575700480</li>
+<li>https://twitter.com/slava_pestov/status/857382737669271552</li>
+</ul>
+</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="https://kobiton.com/swiftunwrapped">Kobiton</a>: complete mobile device lab solution.</p>
+<p>Start a 15 day free trial today at https://kobiton.com/swiftunwrapped.</p>
+]]></description>
+      <pubDate>Mon, 22 May 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Moving to Discourse, email from Ted: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170206/031657.html</li>
+<li>Nate Cook's Discourse experiment: http://discourse.natecook.com/</li>
+<li>Slava tweets:
+<ul>
+<li>https://twitter.com/slava_pestov/status/854490613575700480</li>
+<li>https://twitter.com/slava_pestov/status/857382737669271552</li>
+</ul>
+</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="https://kobiton.com/swiftunwrapped">Kobiton</a>: complete mobile device lab solution.</p>
+<p>Start a 15 day free trial today at https://kobiton.com/swiftunwrapped.</p>
+]]></content:encoded>
+      <enclosure length="25803701" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/03e313d9-9a1d-4efd-884a-e95ba545ad61/12-swift-evolution_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>12: Swift Evolution</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/03e313d9-9a1d-4efd-884a-e95ba545ad61/3000x3000/1494901572-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:26:48</itunes:duration>
+      <itunes:summary>We debate if Swift evolution is pulling its weight, and if it&apos;s possible for Swift to remain &quot;open&quot; without  the cost.</itunes:summary>
+      <itunes:subtitle>We debate if Swift evolution is pulling its weight, and if it&apos;s possible for Swift to remain &quot;open&quot; without  the cost.</itunes:subtitle>
+      <itunes:keywords>forums, swift, discourse, swift-evolution, community, programming, objective-c, mailing lists</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>13</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">727f3454-6204-4c44-9202-451986ec3a39</guid>
+      <title>11: Ownership Manifesto</title>
+      <description><![CDATA[<ul>
+<li>Manifesto: https://github.com/apple/swift/blob/master/docs/OwnershipManifesto.md</li>
+<li>TL;DR: https://gist.github.com/Gankro/1f79fbf2a9776302a9d4c8c0097cc40e</li>
+<li>Graydon Hoare, Swift team member, creator of Rust: https://en.wikipedia.org/wiki/Rust_(programming_language)</li>
+<li>Some work has already landed to enforce exclusivity in Swift 4:
+<ul>
+<li>https://github.com/apple/swift/pull/9373</li>
+<li>https://github.com/apple/swift/pull/9198</li>
+<li>https://github.com/apple/swift/pull/9112</li>
+</ul>
+</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="https://www.buddybuild.com/">BuddyBuild</a>: a continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams.</p>
+<p>Try it free today at https://www.buddybuild.com/.</p>
+]]></description>
+      <pubDate>Mon, 15 May 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>Manifesto: https://github.com/apple/swift/blob/master/docs/OwnershipManifesto.md</li>
+<li>TL;DR: https://gist.github.com/Gankro/1f79fbf2a9776302a9d4c8c0097cc40e</li>
+<li>Graydon Hoare, Swift team member, creator of Rust: https://en.wikipedia.org/wiki/Rust_(programming_language)</li>
+<li>Some work has already landed to enforce exclusivity in Swift 4:
+<ul>
+<li>https://github.com/apple/swift/pull/9373</li>
+<li>https://github.com/apple/swift/pull/9198</li>
+<li>https://github.com/apple/swift/pull/9112</li>
+</ul>
+</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, <a href="https://www.buddybuild.com/">BuddyBuild</a>: a continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams.</p>
+<p>Try it free today at https://www.buddybuild.com/.</p>
+]]></content:encoded>
+      <enclosure length="28006354" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/23ea43f5-838e-4cb4-a9e5-4db00048b40b/11-the-ownership-manifesto_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>11: Ownership Manifesto</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/23ea43f5-838e-4cb4-a9e5-4db00048b40b/3000x3000/1494376167-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:29:06</itunes:duration>
+      <itunes:summary>A brief overview of the complex topic of memory ownership revisions currently underway.</itunes:summary>
+      <itunes:subtitle>A brief overview of the complex topic of memory ownership revisions currently underway.</itunes:subtitle>
+      <itunes:keywords>memory, objective-c, rust, swift, ownership, compilers, programming, swift-evolution</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>12</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">65afbd33-fca4-4b4b-9194-71a6e1e7713e</guid>
+      <title>10: The Variety Show</title>
+      <description><![CDATA[<h1>SE-0168: Multi-line strings</h1>
+<ul>
+<li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0168-multi-line-string-literals.md</li>
+<li>John Holdsworth (Injection4Xcode): https://twitter.com/Injection4Xcode</li>
+<li>Took just over 12 months to land: https://github.com/apple/swift/pull/2275</li>
+<li>Final PR: https://github.com/apple/swift/pull/8813</li>
+<li>Starter Bugs to improve diagnostics: https://bugs.swift.org/browse/SR-4701</li>
+<li>Approval Post: https://lists.swift.org/pipermail/swift-evolution-announce/2017-April/000360.html</li>
+<li>Multi-line string literals in Objective-C: http://stackoverflow.com/questions/797318/how-to-split-a-string-literal-across-multiple-lines-in-c-objective-c</li>
+</ul>
+<p>#SE-0171: Reduce with inout</p>
+<ul>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0171-reduce-with-inout.md</li>
+<li>Rationale: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170424/036126.html</li>
+</ul>
+<h1>SE-0172: One-Sided Ranges</h1>
+<ul>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0172-one-sided-ranges.md</li>
+<li>Rationale: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170424/036125.html</li>
+</ul>
+<h1>Source Compatibility suite</h1>
+<ul>
+<li>Announcement: https://swift.org/blog/swift-source-compatibility-test-suite/</li>
+<li>Swift Source Compatibility Suite: https://github.com/apple/swift-source-compat-suite</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, PerfectlySoft. Find tutorials and other content at http://perfect.org/learn.html</p>
+]]></description>
+      <pubDate>Mon, 8 May 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h1>SE-0168: Multi-line strings</h1>
+<ul>
+<li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0168-multi-line-string-literals.md</li>
+<li>John Holdsworth (Injection4Xcode): https://twitter.com/Injection4Xcode</li>
+<li>Took just over 12 months to land: https://github.com/apple/swift/pull/2275</li>
+<li>Final PR: https://github.com/apple/swift/pull/8813</li>
+<li>Starter Bugs to improve diagnostics: https://bugs.swift.org/browse/SR-4701</li>
+<li>Approval Post: https://lists.swift.org/pipermail/swift-evolution-announce/2017-April/000360.html</li>
+<li>Multi-line string literals in Objective-C: http://stackoverflow.com/questions/797318/how-to-split-a-string-literal-across-multiple-lines-in-c-objective-c</li>
+</ul>
+<p>#SE-0171: Reduce with inout</p>
+<ul>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0171-reduce-with-inout.md</li>
+<li>Rationale: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170424/036126.html</li>
+</ul>
+<h1>SE-0172: One-Sided Ranges</h1>
+<ul>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0172-one-sided-ranges.md</li>
+<li>Rationale: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170424/036125.html</li>
+</ul>
+<h1>Source Compatibility suite</h1>
+<ul>
+<li>Announcement: https://swift.org/blog/swift-source-compatibility-test-suite/</li>
+<li>Swift Source Compatibility Suite: https://github.com/apple/swift-source-compat-suite</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, PerfectlySoft. Find tutorials and other content at http://perfect.org/learn.html</p>
+]]></content:encoded>
+      <enclosure length="34485470" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/40579ec4-0543-4028-b5e4-57c06a3457e9/10_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>10: The Variety Show</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/40579ec4-0543-4028-b5e4-57c06a3457e9/3000x3000/1493344262-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:47:48</itunes:duration>
+      <itunes:summary>We cover 3 recent Swift Evolution proposals and the new Swift Compatibility Test Suite.</itunes:summary>
+      <itunes:subtitle>We cover 3 recent Swift Evolution proposals and the new Swift Compatibility Test Suite.</itunes:subtitle>
+      <itunes:keywords>compilers, functional programming, swift, strings, ruby, swift-evolution, programming, testing, objective-c</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>11</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">1e581335-2d96-4a8b-8cc3-d97a0bdef321</guid>
+      <title>09: String Manifesto</title>
+      <description><![CDATA[<ul>
+<li>String Manifesto: https://github.com/apple/swift/blob/master/docs/StringManifesto.md</li>
+<li>Chris Lattner on Swift 4 goals including String re-evaluation: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160725/025676.html</li>
+<li>Ole Begemann:
+<ul>
+<li>Why String.CharacterView is not a MutableCollection: https://oleb.net/blog/2017/02/why-is-string-characterview-not-a-mutablecollection/</li>
+<li>One for the Unicode Nerds: https://oleb.net/blog/2014/06/one-for-the-unicode-nerds/</li>
+</ul>
+</li>
+<li>Objc.io article on unicode: https://www.objc.io/issues/9-strings/unicode/</li>
+<li>Unsafe API proposal: https://github.com/apple/swift/pull/7479</li>
+<li>SipHash:
+<ul>
+<li>https://github.com/apple/swift/blob/master/stdlib/public/core/SipHash.swift.gyb</li>
+<li>https://github.com/apple/swift/pull/4621</li>
+</ul>
+</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, PerfectlySoft. Find tutorials and other content at http://perfect.org/learn.html</p>
+]]></description>
+      <pubDate>Mon, 1 May 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<ul>
+<li>String Manifesto: https://github.com/apple/swift/blob/master/docs/StringManifesto.md</li>
+<li>Chris Lattner on Swift 4 goals including String re-evaluation: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160725/025676.html</li>
+<li>Ole Begemann:
+<ul>
+<li>Why String.CharacterView is not a MutableCollection: https://oleb.net/blog/2017/02/why-is-string-characterview-not-a-mutablecollection/</li>
+<li>One for the Unicode Nerds: https://oleb.net/blog/2014/06/one-for-the-unicode-nerds/</li>
+</ul>
+</li>
+<li>Objc.io article on unicode: https://www.objc.io/issues/9-strings/unicode/</li>
+<li>Unsafe API proposal: https://github.com/apple/swift/pull/7479</li>
+<li>SipHash:
+<ul>
+<li>https://github.com/apple/swift/blob/master/stdlib/public/core/SipHash.swift.gyb</li>
+<li>https://github.com/apple/swift/pull/4621</li>
+</ul>
+</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, PerfectlySoft. Find tutorials and other content at http://perfect.org/learn.html</p>
+]]></content:encoded>
+      <enclosure length="37404160" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/29d93d56-01d6-427f-8b9b-61fb5e5928ea/09-string-manifesto_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>09: String Manifesto</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/29d93d56-01d6-427f-8b9b-61fb5e5928ea/3000x3000/1492799911-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:38:53</itunes:duration>
+      <itunes:summary>We go in way over our heads into Swift&apos;s String Manifesto.</itunes:summary>
+      <itunes:subtitle>We go in way over our heads into Swift&apos;s String Manifesto.</itunes:subtitle>
+      <itunes:keywords>hashing, swift, perl, strings, compilers, programming, objective-c, unicode, swift-evolution, regular expressions, regex</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>10</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">d7ba5b40-3667-4642-902b-7a1093bce0c1</guid>
+      <title>08: Archival Serialization &amp; Swift Encoders</title>
+      <description><![CDATA[<h1>SE-0166: Swift Archival &amp; Serialization</h1>
+<ul>
+<li>NSCoding:
+<ul>
+<li>https://developer.apple.com/reference/foundation/nscoding</li>
+<li>http://nshipster.com/nscoding/</li>
+</ul>
+</li>
+<li>Swift Archival &amp; Serialization: https://github.com/apple/swift-evolution/blob/master/proposals/0166-swift-archival-serialization.md</li>
+<li>ABI Stability Dashboard: https://swift.org/abi-stability/</li>
+</ul>
+<h1>SE-0167: Swift Encoders</h1>
+<ul>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0167-swift-encoders.md</li>
+<li>Semantics of Codable Types in Archives</li>
+<li>NSValueTransformer
+<ul>
+<li>https://developer.apple.com/reference/foundation/nsvaluetransformer</li>
+<li>http://nshipster.com/nsvaluetransformer/</li>
+</ul>
+</li>
+<li>&quot;In the future, we may add API to allow Swift types to provide an Objective-C class to decode as, effectively allowing for user bridging across archival.&quot;</li>
+<li>Similar to Russ Bishop’s proposal
+<ul>
+<li>Allow Swift types to provide custom Objective-C representations</li>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0058-objectivecbridgeable.md</li>
+</ul>
+</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, PerfectlySoft. Download the Perfect Assistant for free at http://perfect.org/en/assistant/</p>
+]]></description>
+      <pubDate>Mon, 24 Apr 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h1>SE-0166: Swift Archival &amp; Serialization</h1>
+<ul>
+<li>NSCoding:
+<ul>
+<li>https://developer.apple.com/reference/foundation/nscoding</li>
+<li>http://nshipster.com/nscoding/</li>
+</ul>
+</li>
+<li>Swift Archival &amp; Serialization: https://github.com/apple/swift-evolution/blob/master/proposals/0166-swift-archival-serialization.md</li>
+<li>ABI Stability Dashboard: https://swift.org/abi-stability/</li>
+</ul>
+<h1>SE-0167: Swift Encoders</h1>
+<ul>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0167-swift-encoders.md</li>
+<li>Semantics of Codable Types in Archives</li>
+<li>NSValueTransformer
+<ul>
+<li>https://developer.apple.com/reference/foundation/nsvaluetransformer</li>
+<li>http://nshipster.com/nsvaluetransformer/</li>
+</ul>
+</li>
+<li>&quot;In the future, we may add API to allow Swift types to provide an Objective-C class to decode as, effectively allowing for user bridging across archival.&quot;</li>
+<li>Similar to Russ Bishop’s proposal
+<ul>
+<li>Allow Swift types to provide custom Objective-C representations</li>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0058-objectivecbridgeable.md</li>
+</ul>
+</li>
+</ul>
+<h3>Thank You</h3>
+<p>Thanks to this episode's sponsor, PerfectlySoft. Download the Perfect Assistant for free at http://perfect.org/en/assistant/</p>
+]]></content:encoded>
+      <enclosure length="28843306" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7abb2eb7-a74f-4eef-b2af-19b360ce9afe/08-proposalreviews_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>08: Archival Serialization &amp; Swift Encoders</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7abb2eb7-a74f-4eef-b2af-19b360ce9afe/3000x3000/1492637286-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:29:59</itunes:duration>
+      <itunes:summary>We unpack the recent SE proposals on serialization &amp; encoding.</itunes:summary>
+      <itunes:subtitle>We unpack the recent SE proposals on serialization &amp; encoding.</itunes:subtitle>
+      <itunes:keywords>encoding, swift-evolution, serialization, swift, programming, decoding, objective-c, compilers, archival</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>9</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">13dd70a1-47b8-4e6d-a05b-b79cb2966ea6</guid>
+      <title>07: Access Control - The Saga Continues</title>
+      <description><![CDATA[<h3>Access Control Roller Coaster</h3>
+<ul>
+<li>First came the private/fileprivate change (SE-0025): https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md</li>
+<li>Then came open (SE-0117): https://github.com/apple/swift-evolution/blob/master/proposals/0117-non-public-subclassable-by-default.md</li>
+<li>For the last few weeks, a faction in the community has been proposing undoing it (SE-0159): https://github.com/apple/swift-evolution/blob/master/proposals/0159-fix-private-access-levels.md
+<ul>
+<li>Wow. Such email. Very list. https://twitter.com/swiftlybrief/status/846938309666492417</li>
+</ul>
+</li>
+<li>Rejection email: https://lists.swift.org/pipermail/swift-evolution-announce/2017-April/000337.html</li>
+<li>Doug Gregor opens discussion for expanding private: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170403/034903.html</li>
+<li>David Hart, with a new proposal from Doug’s suggestions: https://github.com/apple/swift-evolution/pull/668</li>
+<li>http://www.jessesquires.com/thoughts-on-swift-access-control/</li>
+</ul>
+<h3>Modules</h3>
+<ul>
+<li>Features shouldn't be designed and deliberated in isolation. Decisions need to be holistic and forward-thinking. It's the project management equivalent of ABI resilience. &quot;Design Resilience&quot;.</li>
+<li>Robert Widmann's draft modules proposal: https://gist.github.com/CodaFi/cd66b7d70b5cd8e4e8b433fa2ace378a
+<ul>
+<li>fileprivate access can be recreated by creating a private &quot;utility submodule&quot; containing declarations of at least internal access.</li>
+</ul>
+</li>
+</ul>
+<p>###Thank You</p>
+<p>Thanks to this episode's sponsor, PerfectlySoft. Download the Perfect Assistant for free at http://perfect.org/en/assistant/</p>
+]]></description>
+      <pubDate>Mon, 17 Apr 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h3>Access Control Roller Coaster</h3>
+<ul>
+<li>First came the private/fileprivate change (SE-0025): https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md</li>
+<li>Then came open (SE-0117): https://github.com/apple/swift-evolution/blob/master/proposals/0117-non-public-subclassable-by-default.md</li>
+<li>For the last few weeks, a faction in the community has been proposing undoing it (SE-0159): https://github.com/apple/swift-evolution/blob/master/proposals/0159-fix-private-access-levels.md
+<ul>
+<li>Wow. Such email. Very list. https://twitter.com/swiftlybrief/status/846938309666492417</li>
+</ul>
+</li>
+<li>Rejection email: https://lists.swift.org/pipermail/swift-evolution-announce/2017-April/000337.html</li>
+<li>Doug Gregor opens discussion for expanding private: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170403/034903.html</li>
+<li>David Hart, with a new proposal from Doug’s suggestions: https://github.com/apple/swift-evolution/pull/668</li>
+<li>http://www.jessesquires.com/thoughts-on-swift-access-control/</li>
+</ul>
+<h3>Modules</h3>
+<ul>
+<li>Features shouldn't be designed and deliberated in isolation. Decisions need to be holistic and forward-thinking. It's the project management equivalent of ABI resilience. &quot;Design Resilience&quot;.</li>
+<li>Robert Widmann's draft modules proposal: https://gist.github.com/CodaFi/cd66b7d70b5cd8e4e8b433fa2ace378a
+<ul>
+<li>fileprivate access can be recreated by creating a private &quot;utility submodule&quot; containing declarations of at least internal access.</li>
+</ul>
+</li>
+</ul>
+<p>###Thank You</p>
+<p>Thanks to this episode's sponsor, PerfectlySoft. Download the Perfect Assistant for free at http://perfect.org/en/assistant/</p>
+]]></content:encoded>
+      <enclosure length="36506140" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f4d33606-5e7d-45c0-baab-16265528d571/07-access-control_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>07: Access Control - The Saga Continues</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f4d33606-5e7d-45c0-baab-16265528d571/3000x3000/1491869910-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:37:57</itunes:duration>
+      <itunes:summary>There has been a ton of debate on the Swift Evolution mailing lists about access control in Swift. We share our thoughts on the situation.</itunes:summary>
+      <itunes:subtitle>There has been a ton of debate on the Swift Evolution mailing lists about access control in Swift. We share our thoughts on the situation.</itunes:subtitle>
+      <itunes:keywords>compilers, objective-c, swift, swiftpm, spm, programming, swift-evolution, swift package manager</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>8</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">3955518d-2cf2-4ec6-9565-38cb72e02add</guid>
+      <title>06: Swift 3.1 Release &amp; SwiftPM Improvements</title>
+      <description><![CDATA[<h3>Swift 3.1 Release</h3>
+<ul>
+<li>Official Swift 3.1 release post: https://swift.org/blog/swift-3-1-released/</li>
+<li>Swift 3.1 was first available on Swift for iPad, not macOS 🙀
+<ul>
+<li>https://twitter.com/stroughtonsmith/status/844451069228994560</li>
+</ul>
+</li>
+<li>Anna Zaks, program analysis at Apple: https://twitter.com/zaks_anna</li>
+<li>Visual Debugging with Xcode WWDC 2016: https://developer.apple.com/videos/play/wwdc2016/410/</li>
+<li>ASAN: https://en.wikipedia.org/wiki/AddressSanitizer</li>
+<li>TSAN: https://clang.llvm.org/docs/ThreadSanitizer.html</li>
+<li>TSAN at WWDC 2016: https://developer.apple.com/videos/play/wwdc2016/412/</li>
+</ul>
+<h3>SPM Improvements</h3>
+<ul>
+<li>Package Manager Manifest API Redesign: https://github.com/apple/swift-evolution/blob/master/proposals/0158-package-manager-manifest-api-redesign.md</li>
+<li>Package Manager Editable Packages: https://github.com/apple/swift-evolution/blob/master/proposals/0082-swiftpm-package-edit.md</li>
+<li>Package Manager Version Pinning: https://github.com/apple/swift-evolution/blob/master/proposals/0145-package-manager-version-pinning.md</li>
+<li>Package Manager Tools Version: https://github.com/apple/swift-evolution/blob/master/proposals/0152-package-manager-tools-version.md</li>
+<li>Package Manager Swift Language Compatibility Version: https://github.com/apple/swift-evolution/blob/master/proposals/0151-package-manager-swift-language-compatibility-version.md</li>
+<li>Lots of SwiftPM proposals &amp; changes came in under the wire. Kudos to Ankit and Daniel.</li>
+</ul>
+<p>Thanks to this episode's sponsor, PerfectlySoft. Download the Perfect Assistant for free at http://perfect.org/en/assistant/</p>
+]]></description>
+      <pubDate>Mon, 10 Apr 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<h3>Swift 3.1 Release</h3>
+<ul>
+<li>Official Swift 3.1 release post: https://swift.org/blog/swift-3-1-released/</li>
+<li>Swift 3.1 was first available on Swift for iPad, not macOS 🙀
+<ul>
+<li>https://twitter.com/stroughtonsmith/status/844451069228994560</li>
+</ul>
+</li>
+<li>Anna Zaks, program analysis at Apple: https://twitter.com/zaks_anna</li>
+<li>Visual Debugging with Xcode WWDC 2016: https://developer.apple.com/videos/play/wwdc2016/410/</li>
+<li>ASAN: https://en.wikipedia.org/wiki/AddressSanitizer</li>
+<li>TSAN: https://clang.llvm.org/docs/ThreadSanitizer.html</li>
+<li>TSAN at WWDC 2016: https://developer.apple.com/videos/play/wwdc2016/412/</li>
+</ul>
+<h3>SPM Improvements</h3>
+<ul>
+<li>Package Manager Manifest API Redesign: https://github.com/apple/swift-evolution/blob/master/proposals/0158-package-manager-manifest-api-redesign.md</li>
+<li>Package Manager Editable Packages: https://github.com/apple/swift-evolution/blob/master/proposals/0082-swiftpm-package-edit.md</li>
+<li>Package Manager Version Pinning: https://github.com/apple/swift-evolution/blob/master/proposals/0145-package-manager-version-pinning.md</li>
+<li>Package Manager Tools Version: https://github.com/apple/swift-evolution/blob/master/proposals/0152-package-manager-tools-version.md</li>
+<li>Package Manager Swift Language Compatibility Version: https://github.com/apple/swift-evolution/blob/master/proposals/0151-package-manager-swift-language-compatibility-version.md</li>
+<li>Lots of SwiftPM proposals &amp; changes came in under the wire. Kudos to Ankit and Daniel.</li>
+</ul>
+<p>Thanks to this episode's sponsor, PerfectlySoft. Download the Perfect Assistant for free at http://perfect.org/en/assistant/</p>
+]]></content:encoded>
+      <enclosure length="43065997" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/43598351-fe72-46a5-ac3c-c1fe7619094c/06-swift-3-1-release_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>06: Swift 3.1 Release &amp; SwiftPM Improvements</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/43598351-fe72-46a5-ac3c-c1fe7619094c/3000x3000/1491278516-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:44:47</itunes:duration>
+      <itunes:summary>This week we celebrate the release of Swift 3.1 and the large set of improvements to SwiftPM that happened just under the wire.</itunes:summary>
+      <itunes:subtitle>This week we celebrate the release of Swift 3.1 and the large set of improvements to SwiftPM that happened just under the wire.</itunes:subtitle>
+      <itunes:keywords>compilers, address sanitizer, swift, programming, thread sanitizer, swift-evolution, swift package manager, objective-c, spm, swiftpm</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>7</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">dfdb442d-0328-4bd9-934d-3349ae58474c</guid>
+      <title>05: Objective-C Interoperability</title>
+      <description><![CDATA[<p>There's been a much stronger focus on calling ObjC from Swift than the other way around, but in this talk we'll cover both directions and the parts of the Swift language involved in the process.</p>
+<h3>ObjC Interop Overview</h3>
+<ul>
+<li>Nikita Lutsenko's talk: https://realm.io/news/altconf-nikita-lutsenko-objc-swift-interoperability/
+<ul>
+<li>NS_SWIFT_NAME</li>
+<li>NS_SWIFT_UNAVAILABLE</li>
+<li>NS_REFINED_FOR_SWIFT</li>
+<li>NS_SWIFT_NOTHROW</li>
+<li>NS_NOESCAPE</li>
+<li>NSEXTENSIBLESTRING_ENUM</li>
+<li>Nullability Annotations</li>
+<li>Generic Annotations</li>
+</ul>
+</li>
+<li>ClangImporter (omit needless words logic lives here)</li>
+<li>PrintAsObjC
+<ul>
+<li>Kevin Ballard's PR to include unavailable/deprecated/availability attributes: https://github.com/apple/swift/pull/6480</li>
+<li>ObjC codegen via string manipulation. Very hackable.</li>
+</ul>
+</li>
+</ul>
+<h3>Proposals on ObjC Interop</h3>
+<ul>
+<li>Referencing ObjC key-paths: https://github.com/apple/swift-evolution/blob/master/proposals/0062-objc-keypaths.md</li>
+<li>Referencing ObjC property selectors: https://github.com/apple/swift-evolution/blob/master/proposals/0064-property-selectors.md</li>
+<li>Referencing ObjC selector of a method: https://github.com/apple/swift-evolution/blob/master/proposals/0022-objc-selectors.md</li>
+<li>Great API transformation: https://github.com/apple/swift-evolution/blob/master/proposals/0005-objective-c-name-translation.md</li>
+<li>Import ObjC constants: https://github.com/apple/swift-evolution/blob/master/proposals/0033-import-objc-constants.md</li>
+<li>Make optional requirements ObjC only: https://github.com/apple/swift-evolution/blob/master/proposals/0070-optional-requirements.md</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 3 Apr 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>There's been a much stronger focus on calling ObjC from Swift than the other way around, but in this talk we'll cover both directions and the parts of the Swift language involved in the process.</p>
+<h3>ObjC Interop Overview</h3>
+<ul>
+<li>Nikita Lutsenko's talk: https://realm.io/news/altconf-nikita-lutsenko-objc-swift-interoperability/
+<ul>
+<li>NS_SWIFT_NAME</li>
+<li>NS_SWIFT_UNAVAILABLE</li>
+<li>NS_REFINED_FOR_SWIFT</li>
+<li>NS_SWIFT_NOTHROW</li>
+<li>NS_NOESCAPE</li>
+<li>NSEXTENSIBLESTRING_ENUM</li>
+<li>Nullability Annotations</li>
+<li>Generic Annotations</li>
+</ul>
+</li>
+<li>ClangImporter (omit needless words logic lives here)</li>
+<li>PrintAsObjC
+<ul>
+<li>Kevin Ballard's PR to include unavailable/deprecated/availability attributes: https://github.com/apple/swift/pull/6480</li>
+<li>ObjC codegen via string manipulation. Very hackable.</li>
+</ul>
+</li>
+</ul>
+<h3>Proposals on ObjC Interop</h3>
+<ul>
+<li>Referencing ObjC key-paths: https://github.com/apple/swift-evolution/blob/master/proposals/0062-objc-keypaths.md</li>
+<li>Referencing ObjC property selectors: https://github.com/apple/swift-evolution/blob/master/proposals/0064-property-selectors.md</li>
+<li>Referencing ObjC selector of a method: https://github.com/apple/swift-evolution/blob/master/proposals/0022-objc-selectors.md</li>
+<li>Great API transformation: https://github.com/apple/swift-evolution/blob/master/proposals/0005-objective-c-name-translation.md</li>
+<li>Import ObjC constants: https://github.com/apple/swift-evolution/blob/master/proposals/0033-import-objc-constants.md</li>
+<li>Make optional requirements ObjC only: https://github.com/apple/swift-evolution/blob/master/proposals/0070-optional-requirements.md</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="39221495" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4d4cb17a-c90c-4e34-8d11-6e0170c1b839/05-objectivec-interop_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>05: Objective-C Interoperability</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4d4cb17a-c90c-4e34-8d11-6e0170c1b839/3000x3000/1488675570-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:40:47</itunes:duration>
+      <itunes:summary>Continuing from episode 4&apos;s take on Objective-C Bridging, in this episode we look at Objective-C interoperability.</itunes:summary>
+      <itunes:subtitle>Continuing from episode 4&apos;s take on Objective-C Bridging, in this episode we look at Objective-C interoperability.</itunes:subtitle>
+      <itunes:keywords>objective-c, swift, clang, programming, bridging, compilers, foundation, swift-evolution</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>6</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">e7614b4b-dd8a-4fa3-b02d-2c833c712fe8</guid>
+      <title>04: Bridging with Objective-C</title>
+      <description><![CDATA[<p>Swift has evolved since 1.x to have a fluctuating amount of magic/implicit bridging from ObjC and Foundation types, sometimes going in the opposite direction towards very explicit type conversions.</p>
+<p>We've started seeing more of what the &quot;steady state&quot; looks like as Swift 3.x/4.x development matures.</p>
+<p>In the early days, Swift users would need deep compiler internal implementation details to know which NSNumber-representable type could implicitly convert. As of <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0139-bridge-nsnumber-and-nsvalue.md">SE-0139</a> that's a lot clearer.</p>
+<p>The subtleties of unenforced protocol conformance semantics: https://oleb.net/blog/2016/12/protocols-have-semantics/</p>
+<h2>Proposals on bridging</h2>
+<ul>
+<li>New from Doug Gregor, limiting <code>@objc</code> inference: https://github.com/DougGregor/swift-evolution/blob/objc-inference/proposals/NNNN-objc-inference.md</li>
+<li><code>NSNumber</code> and <code>NSValue</code>: https://github.com/apple/swift-evolution/blob/master/proposals/0139-bridge-nsnumber-and-nsvalue.md</li>
+<li>Optional to payload or <code>NSNull</code>: https://github.com/apple/swift-evolution/blob/master/proposals/0140-bridge-optional-to-nsnull.md</li>
+<li>ObjC lightweight generics: https://github.com/apple/swift-evolution/blob/master/proposals/0057-importing-objc-generics.md</li>
+<li>Import <code>id</code> as <code>Any</code>: https://github.com/apple/swift-evolution/blob/master/proposals/0116-id-as-any.md</li>
+<li><code>NSError</code> bridging: https://github.com/apple/swift-evolution/blob/master/proposals/0112-nserror-bridging.md</li>
+<li>Fully eliminate implicit bridging: https://github.com/apple/swift-evolution/blob/master/proposals/0072-eliminate-implicit-bridging-conversions.md</li>
+<li>Remove bridging conversion behavior from dynamic casts: https://github.com/apple/swift-evolution/blob/master/proposals/0083-remove-bridging-from-dynamic-casts.md</li>
+<li>Ole Begemann on &quot;Protocols are more than Bags of Syntax&quot;: https://oleb.net/blog/2016/12/protocols-have-semantics/</li>
+<li>No protocol for non-user constructable types (e.g. library-vendored types) :(</li>
+<li>Conventions are useful, even if not for technical reasons. Case study with Realm trying to buck NSError ObjC conventions: https://github.com/realm/realm-cocoa/pull/1123</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 27 Mar 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>Swift has evolved since 1.x to have a fluctuating amount of magic/implicit bridging from ObjC and Foundation types, sometimes going in the opposite direction towards very explicit type conversions.</p>
+<p>We've started seeing more of what the &quot;steady state&quot; looks like as Swift 3.x/4.x development matures.</p>
+<p>In the early days, Swift users would need deep compiler internal implementation details to know which NSNumber-representable type could implicitly convert. As of <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0139-bridge-nsnumber-and-nsvalue.md">SE-0139</a> that's a lot clearer.</p>
+<p>The subtleties of unenforced protocol conformance semantics: https://oleb.net/blog/2016/12/protocols-have-semantics/</p>
+<h2>Proposals on bridging</h2>
+<ul>
+<li>New from Doug Gregor, limiting <code>@objc</code> inference: https://github.com/DougGregor/swift-evolution/blob/objc-inference/proposals/NNNN-objc-inference.md</li>
+<li><code>NSNumber</code> and <code>NSValue</code>: https://github.com/apple/swift-evolution/blob/master/proposals/0139-bridge-nsnumber-and-nsvalue.md</li>
+<li>Optional to payload or <code>NSNull</code>: https://github.com/apple/swift-evolution/blob/master/proposals/0140-bridge-optional-to-nsnull.md</li>
+<li>ObjC lightweight generics: https://github.com/apple/swift-evolution/blob/master/proposals/0057-importing-objc-generics.md</li>
+<li>Import <code>id</code> as <code>Any</code>: https://github.com/apple/swift-evolution/blob/master/proposals/0116-id-as-any.md</li>
+<li><code>NSError</code> bridging: https://github.com/apple/swift-evolution/blob/master/proposals/0112-nserror-bridging.md</li>
+<li>Fully eliminate implicit bridging: https://github.com/apple/swift-evolution/blob/master/proposals/0072-eliminate-implicit-bridging-conversions.md</li>
+<li>Remove bridging conversion behavior from dynamic casts: https://github.com/apple/swift-evolution/blob/master/proposals/0083-remove-bridging-from-dynamic-casts.md</li>
+<li>Ole Begemann on &quot;Protocols are more than Bags of Syntax&quot;: https://oleb.net/blog/2016/12/protocols-have-semantics/</li>
+<li>No protocol for non-user constructable types (e.g. library-vendored types) :(</li>
+<li>Conventions are useful, even if not for technical reasons. Case study with Realm trying to buck NSError ObjC conventions: https://github.com/realm/realm-cocoa/pull/1123</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="28658447" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/924a610c-8d9a-466b-8e39-2ce293908cf4/04-bridging-with-objective-c_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>04: Bridging with Objective-C</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/924a610c-8d9a-466b-8e39-2ce293908cf4/3000x3000/1488673934-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:39:43</itunes:duration>
+      <itunes:summary>There&apos;s been a constant push and pull on ObjC bridging since Swift 1.x, trying to seek a balance but always swaying in the other direction.</itunes:summary>
+      <itunes:subtitle>There&apos;s been a constant push and pull on ObjC bridging since Swift 1.x, trying to seek a balance but always swaying in the other direction.</itunes:subtitle>
+      <itunes:keywords>runtime, swift, swift-evolution, programming, objective-c, bridging, foundation, compilers</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>5</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">c9bd21d0-1716-4389-a094-de5cbe8728b0</guid>
+      <title>03: Source Stability (What is a Source Breaking Change?)</title>
+      <description><![CDATA[<p>Every Swift developer who has migrated code bases from Swift 1.x to 2.x, or even the more tedious 2.x to 3.x knows the pain of migrating to new Swift versions.</p>
+<p>In this episode, we cover:</p>
+<ul>
+<li>What is a source breaking change?</li>
+<li>Almost guaranteeing that code that compiles with Swift 3.0 continues to compile with Swift 3.x and even Swift 4.x in Swift 3 mode. Why almost? Because it may be best to prevent code that never <em>should have</em> compiled with Swift 3.0 (i.e. compiled due to egregious bugs in the compiler) from compiling as those bugs are fixed. There are times when breaking compilation is preferable to continuing to exploit Swift bugs.</li>
+<li>&quot;we should try to get the “rearrange all the deckchairs” changes into Swift 3 if possible, to make Swift 3 to 4 as smooth as possible&quot;: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160125/007737.html</li>
+<li>Community-driven breakage ;)</li>
+<li>Slava Pestov (<a href="https://twitter.com/slava_pestov">@slava_pestov</a>) found <a href="https://github.com/apple/swift/commit/30c4235193b64050f8110ef5598c7efb4501e0da">and fixed</a> a 'horrific' Swift 3 compatibility bug. When they say Swift 3.1 will be compatible with Swift 3, <a href="https://twitter.com/jckarter/status/809134772786036736">they're serious</a>. 😅</li>
+</ul>
+<hr />
+<ul>
+<li>Dollar Sign
+<ul>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0144-allow-single-dollar-sign-as-valid-identifier.md</li>
+</ul>
+</li>
+<li>Swift Weekly
+<ul>
+<li>Issue 39, https://swiftweekly.github.io/issue-39/
+<ul>
+<li>Slava Pestov changed variadic closure arguments to be @escaping by default, which is technically a source breaking change, but only for invalid code.</li>
+</ul>
+</li>
+<li>Issue 42, https://swiftweekly.github.io/issue-42/
+<ul>
+<li>Robert Widmann merged changes to reject standalone $ as identifiers, which were accidentally accepted as valid.</li>
+</ul>
+</li>
+<li>Issue 43, https://swiftweekly.github.io/issue-43/
+<ul>
+<li>Rintaro Ishizaki has submitted a pull request to fix SR-2843. In type parsing, P1 &amp; P2.Type (new protocol syntax) was incorrect.</li>
+<li>DougGregor fixed an unintentional source-breaking change from Swift 3 regarding implicitly-unwrapped optionals and type inference.</li>
+</ul>
+</li>
+</ul>
+</li>
+<li>Minor source breaking change for sugared types: https://github.com/apple/swift/commit/4ebac86895383ad15e34de3671c6f423e96cfc98</li>
+<li>Running the entire test suite with version 3 or 4: https://github.com/apple/swift/commit/1fcd7d725d1c23a27d4ea31e34e20f182e0b8c37</li>
+<li>Ignored Labels for single-&quot;Any&quot;-argument functions
+<ul>
+<li>https://github.com/apple/swift/commit/30c4235193b64050f8110ef5598c7efb4501e0da</li>
+</ul>
+</li>
+<li>Xcode 8.2 last release for Swift 2.3!</li>
+</ul>
+<hr />
+<p>Errata:</p>
+<ul>
+<li>Tanner Nelson was behind the <code>Type.self</code> proposal, not Erica Sadun: https://github.com/apple/swift-evolution/blob/master/proposals/0090-remove-dot-self.md</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 20 Mar 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>Every Swift developer who has migrated code bases from Swift 1.x to 2.x, or even the more tedious 2.x to 3.x knows the pain of migrating to new Swift versions.</p>
+<p>In this episode, we cover:</p>
+<ul>
+<li>What is a source breaking change?</li>
+<li>Almost guaranteeing that code that compiles with Swift 3.0 continues to compile with Swift 3.x and even Swift 4.x in Swift 3 mode. Why almost? Because it may be best to prevent code that never <em>should have</em> compiled with Swift 3.0 (i.e. compiled due to egregious bugs in the compiler) from compiling as those bugs are fixed. There are times when breaking compilation is preferable to continuing to exploit Swift bugs.</li>
+<li>&quot;we should try to get the “rearrange all the deckchairs” changes into Swift 3 if possible, to make Swift 3 to 4 as smooth as possible&quot;: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160125/007737.html</li>
+<li>Community-driven breakage ;)</li>
+<li>Slava Pestov (<a href="https://twitter.com/slava_pestov">@slava_pestov</a>) found <a href="https://github.com/apple/swift/commit/30c4235193b64050f8110ef5598c7efb4501e0da">and fixed</a> a 'horrific' Swift 3 compatibility bug. When they say Swift 3.1 will be compatible with Swift 3, <a href="https://twitter.com/jckarter/status/809134772786036736">they're serious</a>. 😅</li>
+</ul>
+<hr />
+<ul>
+<li>Dollar Sign
+<ul>
+<li>https://github.com/apple/swift-evolution/blob/master/proposals/0144-allow-single-dollar-sign-as-valid-identifier.md</li>
+</ul>
+</li>
+<li>Swift Weekly
+<ul>
+<li>Issue 39, https://swiftweekly.github.io/issue-39/
+<ul>
+<li>Slava Pestov changed variadic closure arguments to be @escaping by default, which is technically a source breaking change, but only for invalid code.</li>
+</ul>
+</li>
+<li>Issue 42, https://swiftweekly.github.io/issue-42/
+<ul>
+<li>Robert Widmann merged changes to reject standalone $ as identifiers, which were accidentally accepted as valid.</li>
+</ul>
+</li>
+<li>Issue 43, https://swiftweekly.github.io/issue-43/
+<ul>
+<li>Rintaro Ishizaki has submitted a pull request to fix SR-2843. In type parsing, P1 &amp; P2.Type (new protocol syntax) was incorrect.</li>
+<li>DougGregor fixed an unintentional source-breaking change from Swift 3 regarding implicitly-unwrapped optionals and type inference.</li>
+</ul>
+</li>
+</ul>
+</li>
+<li>Minor source breaking change for sugared types: https://github.com/apple/swift/commit/4ebac86895383ad15e34de3671c6f423e96cfc98</li>
+<li>Running the entire test suite with version 3 or 4: https://github.com/apple/swift/commit/1fcd7d725d1c23a27d4ea31e34e20f182e0b8c37</li>
+<li>Ignored Labels for single-&quot;Any&quot;-argument functions
+<ul>
+<li>https://github.com/apple/swift/commit/30c4235193b64050f8110ef5598c7efb4501e0da</li>
+</ul>
+</li>
+<li>Xcode 8.2 last release for Swift 2.3!</li>
+</ul>
+<hr />
+<p>Errata:</p>
+<ul>
+<li>Tanner Nelson was behind the <code>Type.self</code> proposal, not Erica Sadun: https://github.com/apple/swift-evolution/blob/master/proposals/0090-remove-dot-self.md</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="28533506" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/666053de-af16-4453-bbe1-0c3f1c434846/03-source-stability_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>03: Source Stability (What is a Source Breaking Change?)</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/666053de-af16-4453-bbe1-0c3f1c434846/3000x3000/1488673764-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:29:39</itunes:duration>
+      <itunes:summary>The up (and down) sides of striving for source compatibility across Swift versions. Let&apos;s rearrange some deck chairs!</itunes:summary>
+      <itunes:subtitle>The up (and down) sides of striving for source compatibility across Swift versions. Let&apos;s rearrange some deck chairs!</itunes:subtitle>
+      <itunes:keywords>swift, programming, xcode</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>4</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">448ffe96-c0ee-43a4-9029-5a277c8e4ad8</guid>
+      <title>02: SourceKit (Compiling by Default)</title>
+      <description><![CDATA[<p>In this episode, we dive into the framework we love to hate to love: SourceKit.</p>
+<p>We wrap up with an overview of method dispatch in Swift.</p>
+<h3>SourceKit on Linux</h3>
+<ul>
+<li>Swift core team is fixing compiler crashers faster than they're filed!
+<ul>
+<li><a href="https://twitter.com/slava_pestov">Slava Pestov</a> being a driving force behind many of these fixes.</li>
+<li><a href="https://twitter.com/practicalswift">@practicalswift</a> is basically Swift compiler fuzzing as-a-service ;)</li>
+<li><a href="https://twitter.com/slava_pestov/status/825549445605437440">Undoing all of @practicalswift's hard work</a></li>
+</ul>
+</li>
+<li><a href="https://github.com/apple/swift/tree/master/tools/SourceKit">SourceKit home page</a></li>
+<li><a href="https://github.com/apple/swift/blob/swift-3.0.2-RELEASE/tools/SourceKit/README.txt#L15-L17">Process Isolation</a></li>
+<li>Key contributors to SourceKit:
+<ul>
+<li><a href="https://twitter.com/aikoniv">Brian Croom</a> and his many <a href="https://github.com/apple/swift/pulls?utf8=%E2%9C%93&amp;q=is%3Apr%20author%3Abriancroom%20sourcekit%20is%3Aclosed%20">SourceKit PRs</a> to help get it linking and compiling on Linux.</li>
+<li><a href="https://twitter.com/alblue">Alex Blewitt</a> and <a href="https://github.com/apple/swift/pulls?utf8=%E2%9C%93&amp;q=is%3Apr%20author%3Aalblue%20sourcekit">his numerous attempts</a> at getting SourceKit compiling <em>by default</em> on Linux.</li>
+</ul>
+</li>
+<li><a href="https://bugs.swift.org/browse/SR-1676">SR-1676: Build SourceKit on Linux</a></li>
+<li><a href="https://cmake.org/">CMake homepage</a></li>
+<li><a href="https://github.com/apple/swift-corelibs-libdispatch">swift-corelibs-libdispatch</a></li>
+<li><a href="https://github.com/apple/swift/pull/5903">Final PR to get SourceKit building on Linux: #5903</a></li>
+<li><a href="https://github.com/apple/swift/blob/master/CODE_OWNERS.TXT">CODE_OWNERS.TXT</a></li>
+<li><a href="https://realm.io/news/tryswift-jesse-squires-contributing-open-source-swift/">Jesse's talk at &quot;try! Swift&quot;: Contributing to Open Source Swift</a></li>
+<li><a href="https://atom.io/">Atom Editor</a></li>
+<li><a href="https://atom.io/packages/nuclide">Nuclide Atom Package</a></li>
+<li><a href="https://github.com/krzysztofzablocki/Sourcery">Sourcery codegen tool</a></li>
+</ul>
+<h3>Method Dispatch</h3>
+<ul>
+<li><a href="https://www.raizlabs.com/dev/2016/12/swift-method-dispatch">Raizlabs' article on Method Dispatch in Swift</a></li>
+<li><a href="https://twitter.com/clattner_llvm/status/806564802290008064">Chris Lattner's tweet about the article</a></li>
+<li><a href="https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20161212/029441.html">Swift Evolution thread: Changing NSObject dispatch behavior</a></li>
+<li><a href="http://martiancraft.com/blog/2015/12/nsmanaged/">@NSManaged</a></li>
+<li><a href="http://www.jessesquires.com/avoiding-objc-in-swift/">@objc</a></li>
+</ul>
+]]></description>
+      <pubDate>Mon, 13 Mar 2017 12:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>In this episode, we dive into the framework we love to hate to love: SourceKit.</p>
+<p>We wrap up with an overview of method dispatch in Swift.</p>
+<h3>SourceKit on Linux</h3>
+<ul>
+<li>Swift core team is fixing compiler crashers faster than they're filed!
+<ul>
+<li><a href="https://twitter.com/slava_pestov">Slava Pestov</a> being a driving force behind many of these fixes.</li>
+<li><a href="https://twitter.com/practicalswift">@practicalswift</a> is basically Swift compiler fuzzing as-a-service ;)</li>
+<li><a href="https://twitter.com/slava_pestov/status/825549445605437440">Undoing all of @practicalswift's hard work</a></li>
+</ul>
+</li>
+<li><a href="https://github.com/apple/swift/tree/master/tools/SourceKit">SourceKit home page</a></li>
+<li><a href="https://github.com/apple/swift/blob/swift-3.0.2-RELEASE/tools/SourceKit/README.txt#L15-L17">Process Isolation</a></li>
+<li>Key contributors to SourceKit:
+<ul>
+<li><a href="https://twitter.com/aikoniv">Brian Croom</a> and his many <a href="https://github.com/apple/swift/pulls?utf8=%E2%9C%93&amp;q=is%3Apr%20author%3Abriancroom%20sourcekit%20is%3Aclosed%20">SourceKit PRs</a> to help get it linking and compiling on Linux.</li>
+<li><a href="https://twitter.com/alblue">Alex Blewitt</a> and <a href="https://github.com/apple/swift/pulls?utf8=%E2%9C%93&amp;q=is%3Apr%20author%3Aalblue%20sourcekit">his numerous attempts</a> at getting SourceKit compiling <em>by default</em> on Linux.</li>
+</ul>
+</li>
+<li><a href="https://bugs.swift.org/browse/SR-1676">SR-1676: Build SourceKit on Linux</a></li>
+<li><a href="https://cmake.org/">CMake homepage</a></li>
+<li><a href="https://github.com/apple/swift-corelibs-libdispatch">swift-corelibs-libdispatch</a></li>
+<li><a href="https://github.com/apple/swift/pull/5903">Final PR to get SourceKit building on Linux: #5903</a></li>
+<li><a href="https://github.com/apple/swift/blob/master/CODE_OWNERS.TXT">CODE_OWNERS.TXT</a></li>
+<li><a href="https://realm.io/news/tryswift-jesse-squires-contributing-open-source-swift/">Jesse's talk at &quot;try! Swift&quot;: Contributing to Open Source Swift</a></li>
+<li><a href="https://atom.io/">Atom Editor</a></li>
+<li><a href="https://atom.io/packages/nuclide">Nuclide Atom Package</a></li>
+<li><a href="https://github.com/krzysztofzablocki/Sourcery">Sourcery codegen tool</a></li>
+</ul>
+<h3>Method Dispatch</h3>
+<ul>
+<li><a href="https://www.raizlabs.com/dev/2016/12/swift-method-dispatch">Raizlabs' article on Method Dispatch in Swift</a></li>
+<li><a href="https://twitter.com/clattner_llvm/status/806564802290008064">Chris Lattner's tweet about the article</a></li>
+<li><a href="https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20161212/029441.html">Swift Evolution thread: Changing NSObject dispatch behavior</a></li>
+<li><a href="http://martiancraft.com/blog/2015/12/nsmanaged/">@NSManaged</a></li>
+<li><a href="http://www.jessesquires.com/avoiding-objc-in-swift/">@objc</a></li>
+</ul>
+]]></content:encoded>
+      <enclosure length="31277368" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0a8f7b8f-2786-4ee1-8d05-903664172bbd/02-sourcekit_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>02: SourceKit (Compiling by Default)</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0a8f7b8f-2786-4ee1-8d05-903664172bbd/3000x3000/1488673610-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:32:31</itunes:duration>
+      <itunes:summary>The tumultuous tales of the community getting SourceKit compiling on Linux.</itunes:summary>
+      <itunes:subtitle>The tumultuous tales of the community getting SourceKit compiling on Linux.</itunes:subtitle>
+      <itunes:keywords>swift, linux, tooling, sourcekit, fuzzing</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>3</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">62765dfd-5d6f-4cad-8b9a-de5f2e04a59d</guid>
+      <title>01: Already &amp; Only (Swift Open Source Year in Review)</title>
+      <description><![CDATA[<p>In this episode we take a look at the first full year of open source Swift development and the first complete release cycle (for 3.0) that happened completely in the open. We reflect on where we've been and how we got here. We discuss the initial launch, Swift evolution, the &quot;Great Swift 3 Migration&quot;, and more!</p>
+<ul>
+<li>Open source <a href="https://developer.apple.com/swift/blog/?id=34">announcement</a></li>
+<li>First <a href="https://swift.org/blog/welcome/">Swift.org blog post</a></li>
+<li>First issue of <a href="https://swiftweekly.github.io/issue-0/">Swift Weekly Brief</a></li>
+<li>First <a href="https://github.com/apple/swift/commit/18844bc65229786b96b89a9fc7739c0fc897905e">commit</a> to Swift</li>
+<li><a href="https://swift.org/community/#community-structure">Core Team</a></li>
+<li>Swift Evolution <a href="https://apple.github.io/swift-evolution/">proposals</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0081-move-where-expression.md">SE-0081</a>: Move <code>where</code> clause to end of declaration</li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md">SE-0004</a>: Remove the<code> ++</code> and <code>--</code> operators</li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md">SE-0007</a>: Remove C-style for-loops with conditions and incrementers</li>
+<li>Email: <a href="http://thread.gmane.org/gmane.comp.lang.swift.evolution/17276">Winding down the Swift 3 release</a></li>
+<li>Change to <a href="https://github.com/apple/swift-evolution/commit/06b69a6e51a71a462c268da60b51a18966dba31b">Swift 3 goals</a></li>
+<li>Email: <a href="https://lists.swift.org/pipermail/swift-evolution-announce/2016-July/000264.html">End of source-breaking changes for Swift 3</a></li>
+<li><a href="https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md">Generics Manifesto</a></li>
+<li><a href="https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md">ABI Stability Manifesto</a></li>
+<li>Swift 2 to Swift 3 <a href="https://swift.org/migration-guide/">migration guide</a></li>
+<li>Tooling: <a href="https://github.com/apple/swift/tree/master/tools/SourceKit">SourceKit</a></li>
+<li>Ryan Olson, <a href="https://medium.com/ios-os-x-development/is-apple-using-swift-4a6c80f74599#.rvuxtu4vc">Is Apple Using Swift in iOS?</a>, (<a href="https://news.ycombinator.com/item?id=10923027">Hacker News</a>)</li>
+<li><a href="https://github.com/apple/swift-package-manager">Swift Package Manager</a></li>
+<li><a href="https://www.apple.com/swift/playgrounds/">Swift Playgrounds</a> for iPad</li>
+</ul>
+]]></description>
+      <pubDate>Mon, 6 Mar 2017 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>In this episode we take a look at the first full year of open source Swift development and the first complete release cycle (for 3.0) that happened completely in the open. We reflect on where we've been and how we got here. We discuss the initial launch, Swift evolution, the &quot;Great Swift 3 Migration&quot;, and more!</p>
+<ul>
+<li>Open source <a href="https://developer.apple.com/swift/blog/?id=34">announcement</a></li>
+<li>First <a href="https://swift.org/blog/welcome/">Swift.org blog post</a></li>
+<li>First issue of <a href="https://swiftweekly.github.io/issue-0/">Swift Weekly Brief</a></li>
+<li>First <a href="https://github.com/apple/swift/commit/18844bc65229786b96b89a9fc7739c0fc897905e">commit</a> to Swift</li>
+<li><a href="https://swift.org/community/#community-structure">Core Team</a></li>
+<li>Swift Evolution <a href="https://apple.github.io/swift-evolution/">proposals</a></li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0081-move-where-expression.md">SE-0081</a>: Move <code>where</code> clause to end of declaration</li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md">SE-0004</a>: Remove the<code> ++</code> and <code>--</code> operators</li>
+<li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md">SE-0007</a>: Remove C-style for-loops with conditions and incrementers</li>
+<li>Email: <a href="http://thread.gmane.org/gmane.comp.lang.swift.evolution/17276">Winding down the Swift 3 release</a></li>
+<li>Change to <a href="https://github.com/apple/swift-evolution/commit/06b69a6e51a71a462c268da60b51a18966dba31b">Swift 3 goals</a></li>
+<li>Email: <a href="https://lists.swift.org/pipermail/swift-evolution-announce/2016-July/000264.html">End of source-breaking changes for Swift 3</a></li>
+<li><a href="https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md">Generics Manifesto</a></li>
+<li><a href="https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md">ABI Stability Manifesto</a></li>
+<li>Swift 2 to Swift 3 <a href="https://swift.org/migration-guide/">migration guide</a></li>
+<li>Tooling: <a href="https://github.com/apple/swift/tree/master/tools/SourceKit">SourceKit</a></li>
+<li>Ryan Olson, <a href="https://medium.com/ios-os-x-development/is-apple-using-swift-4a6c80f74599#.rvuxtu4vc">Is Apple Using Swift in iOS?</a>, (<a href="https://news.ycombinator.com/item?id=10923027">Hacker News</a>)</li>
+<li><a href="https://github.com/apple/swift-package-manager">Swift Package Manager</a></li>
+<li><a href="https://www.apple.com/swift/playgrounds/">Swift Playgrounds</a> for iPad</li>
+</ul>
+]]></content:encoded>
+      <enclosure length="36189257" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5ef79daf-bbc9-4654-a335-0f4f7c02bd61/01-already-only_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>01: Already &amp; Only (Swift Open Source Year in Review)</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5ef79daf-bbc9-4654-a335-0f4f7c02bd61/3000x3000/1488673308-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:37:38</itunes:duration>
+      <itunes:summary>A retrospective on one year of open source Swift.</itunes:summary>
+      <itunes:subtitle>A retrospective on one year of open source Swift.</itunes:subtitle>
+      <itunes:keywords>swift, swift open source, swift evolution proposal</itunes:keywords>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>2</itunes:episode>
+    </item>
+    <item>
+      <guid isPermaLink="false">59e380e9-93cc-499c-b325-afb8b384dea1</guid>
+      <title>00: And We&apos;re Live!</title>
+      <description><![CDATA[<p>There are tons of podcasts out there about general Apple/iOS/macOS development but nothing specifically about only the Swift programming language.</p>
+<p>So, we decided to make a podcast about the Swift language and a commentary on the <a href="https://swiftweekly.github.io/">Swift Weekly Brief</a>. This podcast is a continuation on more details about Swift Weekly and our own thoughts on Swift news.</p>
+<p>If you want to connect with us you can find us and reach out on twitter: <a href="https://twitter.com/simjp">JP Simard</a> &amp; <a href="https://twitter.com/jesse_squires">Jesse Squires</a></p>
+<p>Be sure to subscribe so you don't miss episode 01 -  airing on Monday, March 6th and be sure to check out some of the other development shows that are a part of the <a href="https://spec.fm/">Spec Network</a>.</p>
+]]></description>
+      <pubDate>Fri, 24 Feb 2017 13:00:00 +0000</pubDate>
+      <author>shows@spec.fm (Spec)</author>
+      <link>https://spec.fm/podcasts/swift-unwrapped</link>
+      <content:encoded><![CDATA[<p>There are tons of podcasts out there about general Apple/iOS/macOS development but nothing specifically about only the Swift programming language.</p>
+<p>So, we decided to make a podcast about the Swift language and a commentary on the <a href="https://swiftweekly.github.io/">Swift Weekly Brief</a>. This podcast is a continuation on more details about Swift Weekly and our own thoughts on Swift news.</p>
+<p>If you want to connect with us you can find us and reach out on twitter: <a href="https://twitter.com/simjp">JP Simard</a> &amp; <a href="https://twitter.com/jesse_squires">Jesse Squires</a></p>
+<p>Be sure to subscribe so you don't miss episode 01 -  airing on Monday, March 6th and be sure to check out some of the other development shows that are a part of the <a href="https://spec.fm/">Spec Network</a>.</p>
+]]></content:encoded>
+      <enclosure length="2640439" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4ae1942a-835e-4096-a3b1-da86ddc3c902/00-swift-unwrapped_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <itunes:title>00: And We&apos;re Live!</itunes:title>
+      <itunes:author>Spec</itunes:author>
+      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4ae1942a-835e-4096-a3b1-da86ddc3c902/3000x3000/1488077803-artwork.jpg?aid=rss_feed"/>
+      <itunes:duration>00:02:41</itunes:duration>
+      <itunes:summary>Welcome to Swift Unwrapped!
+
+A  weekly, 30-minute show about Swift the language hosted by JP Simard &amp; Jesse Squires</itunes:summary>
+      <itunes:subtitle>Welcome to Swift Unwrapped!
+
+A  weekly, 30-minute show about Swift the language hosted by JP Simard &amp; Jesse Squires</itunes:subtitle>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:episode>1</itunes:episode>
+    </item>
+  </channel>
+</rss>

--- a/feed.xml
+++ b/feed.xml
@@ -17,7 +17,7 @@
     <link>https://swiftunwrapped.github.io</link>
     <itunes:type>episodic</itunes:type>
     <itunes:summary>An audio spin off of Swift Weekly Brief and discussions on the Swift programming language. </itunes:summary>
-    <itunes:author>Spec, JP Simard, Jesse Squires</itunes:author>
+    <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
     <itunes:explicit>no</itunes:explicit>
     <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
     <itunes:new-feed-url>https://feeds.simplecast.com/3pGv88mm</itunes:new-feed-url>
@@ -33,13 +33,13 @@
       <description><![CDATA[<ul><li><a href="https://www.hackingwithswift.com/articles/233/whats-new-in-swift-5-5">Paul Hudson's What's New in Swift 5.5</a></li><li><a href="https://swiftbysundell.com/">Swift By Sundell</a></li><li><a href="https://github.com/davedelong/time">Time by Dave DeLong</a> (mistakenly called Chronos during the show)</li></ul>
 ]]></description>
       <pubDate>Mon, 21 Jun 2021 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul><li><a href="https://www.hackingwithswift.com/articles/233/whats-new-in-swift-5-5">Paul Hudson's What's New in Swift 5.5</a></li><li><a href="https://swiftbysundell.com/">Swift By Sundell</a></li><li><a href="https://github.com/davedelong/time">Time by Dave DeLong</a> (mistakenly called Chronos during the show)</li></ul>
 ]]></content:encoded>
       <enclosure length="27800880" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/9415a7c4-e767-4bc1-8438-e67ff03a542c/audio/59932e5c-d516-4f64-9e02-b1923f03261d/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>92: Deinit</itunes:title>
-      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:duration>00:28:57</itunes:duration>
       <itunes:summary>Jesse and JP talk about Swift 5.5, WWDC 21, how the Swift community has evolved in the 7 years of the language, and wrapping up the show. This is our last episode.
 
@@ -58,13 +58,13 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <description><![CDATA[<h3>Links</h3><ul><li><a href="https://forums.swift.org/t/swift-concurrency-roadmap/41611">Swift concurrency roadmap</a></li><li><a href="https://swiftunwrapped.github.io/episodes/409cbdc5/">Episode 27: Concurrency with Chris Lattner</a></li><li><a href="https://forums.swift.org/t/concurrency-actors-actor-isolation/41613">[Concurrency] Actors & actor isolation</a></li><li><a href="https://forums.swift.org/t/concurrency-interoperability-with-objective-c/41616">[Concurrency] Interoperability with Objective-C</a></li><li><a href="https://forums.swift.org/t/concurrency-structured-concurrency/41622">[Concurrency] Structured concurrency</a></li><li><a href="https://forums.swift.org/t/concurrency-asynchronous-functions/41619">[Concurrency] Asynchronous functions</a></li><li><a href="https://forums.swift.org/t/concurrency-asyncsequence/42417">[Concurrency] AsyncSequence</a></li><li><a href="https://gist.github.com/DougGregor/444575ac67cbd25bfc4b1d4fd241ae93">Swift Concurrency Proposals Dependencies Graph</a></li><li><a href="https://docs.google.com/document/d/1BEO6QwzcYCUhaGyA-WRoM_phRa7O7mGPNIMdSV4StEE">Protocol-based Actor Isolation: Draft #2</a></li><li><a href="https://forums.swift.org/t/actors-are-reference-types-but-why-classes/42281">Actors are reference types, but why classes?</a></li></ul><h3>Sponsors</h3><ul><li><strong>AWS Amplify</strong> - AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 ]]></description>
       <pubDate>Mon, 7 Dec 2020 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>Links</h3><ul><li><a href="https://forums.swift.org/t/swift-concurrency-roadmap/41611">Swift concurrency roadmap</a></li><li><a href="https://swiftunwrapped.github.io/episodes/409cbdc5/">Episode 27: Concurrency with Chris Lattner</a></li><li><a href="https://forums.swift.org/t/concurrency-actors-actor-isolation/41613">[Concurrency] Actors & actor isolation</a></li><li><a href="https://forums.swift.org/t/concurrency-interoperability-with-objective-c/41616">[Concurrency] Interoperability with Objective-C</a></li><li><a href="https://forums.swift.org/t/concurrency-structured-concurrency/41622">[Concurrency] Structured concurrency</a></li><li><a href="https://forums.swift.org/t/concurrency-asynchronous-functions/41619">[Concurrency] Asynchronous functions</a></li><li><a href="https://forums.swift.org/t/concurrency-asyncsequence/42417">[Concurrency] AsyncSequence</a></li><li><a href="https://gist.github.com/DougGregor/444575ac67cbd25bfc4b1d4fd241ae93">Swift Concurrency Proposals Dependencies Graph</a></li><li><a href="https://docs.google.com/document/d/1BEO6QwzcYCUhaGyA-WRoM_phRa7O7mGPNIMdSV4StEE">Protocol-based Actor Isolation: Draft #2</a></li><li><a href="https://forums.swift.org/t/actors-are-reference-types-but-why-classes/42281">Actors are reference types, but why classes?</a></li></ul><h3>Sponsors</h3><ul><li><strong>AWS Amplify</strong> - AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 ]]></content:encoded>
       <enclosure length="43224292" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/0248870d-280f-4df1-8693-c659a1210f4d/audio/1e27b922-a9a5-4678-9203-a539ef1f7b58/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>91: Concurrency, 3 years later</itunes:title>
-      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:duration>00:44:57</itunes:duration>
       <itunes:summary>Three years after first discussing concurrency in Swift with Chris Lattner, we dive into the latest round of proposals and forum discussions — although this time it is actually happening.</itunes:summary>
       <itunes:subtitle>Three years after first discussing concurrency in Swift with Chris Lattner, we dive into the latest round of proposals and forum discussions — although this time it is actually happening.</itunes:subtitle>
@@ -79,13 +79,13 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <description><![CDATA[<h3>Links</h3><ul><li><a href="https://swift.org/blog/swift-atomics/">Announcement blog post</a></li><li><a href="https://twitter.com/lorentey/">Karoy Lorentey</a></li><li><a href="https://github.com/apple/swift-atomics">GitHub Repository</a></li><li><a href="https://forums.swift.org/c/related-projects/swift-atomics">Atomics forum</a></li><li><a href="https://news.ycombinator.com/item?id=24657500">Hacker News Discussion</a></li><li><a href="https://github.com/glessard/swift-atomics">Guillaume Lessard’s existing swift-atomics repo</a></li></ul><h3>Sponsors</h3><ul><li><strong>AWS Amplify</strong> - AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a>.</p>
 ]]></description>
       <pubDate>Mon, 2 Nov 2020 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>Links</h3><ul><li><a href="https://swift.org/blog/swift-atomics/">Announcement blog post</a></li><li><a href="https://twitter.com/lorentey/">Karoy Lorentey</a></li><li><a href="https://github.com/apple/swift-atomics">GitHub Repository</a></li><li><a href="https://forums.swift.org/c/related-projects/swift-atomics">Atomics forum</a></li><li><a href="https://news.ycombinator.com/item?id=24657500">Hacker News Discussion</a></li><li><a href="https://github.com/glessard/swift-atomics">Guillaume Lessard’s existing swift-atomics repo</a></li></ul><h3>Sponsors</h3><ul><li><strong>AWS Amplify</strong> - AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a>.</p>
 ]]></content:encoded>
       <enclosure length="26140572" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/0d6319c6-d943-4a47-9eb0-cd58829472a8/audio/d75cc258-b633-4807-839b-49c17dc299c1/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>90: Swift Atomics</itunes:title>
-      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:duration>00:27:10</itunes:duration>
       <itunes:summary>Today we talk about the latest Swift open source project, Swift Atomics. The library you shouldn&apos;t use but want to anyway.</itunes:summary>
       <itunes:subtitle>Today we talk about the latest Swift open source project, Swift Atomics. The library you shouldn&apos;t use but want to anyway.</itunes:subtitle>
@@ -100,13 +100,13 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <description><![CDATA[<h2>What’s in a Swift runtime?</h2><ul><li><a href="https://belkadan.com/blog/2020/04/Swift-on-Mac-OS-9/">Swift on Mac OS 9</a></li><li><a href="https://belkadan.com/blog/2020/08/Swift-Runtime-Heap-Objects/">Heap Objects</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Type-Layout/">Type Layout</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Type-Metadata/">Type Metadata</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Uniquing-Caches/">Uniquing Caches</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Class-Metadata/">Class Metadata</a></li><li><a href="https://belkadan.com/blog/2020/10/Swift-Runtime-Class-Metadata-Initialization/">Class Metadata Initialization</a></li></ul><h3>Other links</h3><ul><li><a href="https://forums.swift.org/t/guarantee-in-memory-tuple-layout-or-dont/40122">Layout guarantees</a></li><li><a href="https://www.highcaffeinecontent.com/blog/20150124-MPW,-Carbon-and-building-Classic-Mac-OS-apps-in-OS-X">Steve Troughton-Smith’s BitPaint</a></li><li><a href="https://github.com/ksherlock/mpw">@ksherlock’s mpw</a></li><li><a href="https://mikeash.com/pyblog/friday-qa-2017-09-22-swift-4-weak-references.html">An explainer on Swift weak references</a></li></ul><h3>About Jordan</h3><ul><li><a href="https://twitter.com/UINT_MIN">Twitter @UINT_MIN</a></li><li><a href="https://belkadan.com">Belkadan</a></li><li><a href="https://citizensclimatelobby.org">Citizens’ Climate Lobby</a></li></ul><h3> </h3><h3>Sponsors</h3><ul><li><strong>Instabug</strong> - Get Application Performance Monitoring built for mobile apps and stay on top of your app quality with Instabug. Check them out and them them know we sent you at <a href="https://try.instabug.com/SwiftUnwrapped">https://try.instabug.com/SwiftUnwrapped</a></li></ul><p> </p><ul><li><strong>AWS Amplify </strong>- AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3> </h3><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a>.</p>
 ]]></description>
       <pubDate>Mon, 12 Oct 2020 18:10:30 +0000</pubDate>
-      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>What’s in a Swift runtime?</h2><ul><li><a href="https://belkadan.com/blog/2020/04/Swift-on-Mac-OS-9/">Swift on Mac OS 9</a></li><li><a href="https://belkadan.com/blog/2020/08/Swift-Runtime-Heap-Objects/">Heap Objects</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Type-Layout/">Type Layout</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Type-Metadata/">Type Metadata</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Uniquing-Caches/">Uniquing Caches</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Class-Metadata/">Class Metadata</a></li><li><a href="https://belkadan.com/blog/2020/10/Swift-Runtime-Class-Metadata-Initialization/">Class Metadata Initialization</a></li></ul><h3>Other links</h3><ul><li><a href="https://forums.swift.org/t/guarantee-in-memory-tuple-layout-or-dont/40122">Layout guarantees</a></li><li><a href="https://www.highcaffeinecontent.com/blog/20150124-MPW,-Carbon-and-building-Classic-Mac-OS-apps-in-OS-X">Steve Troughton-Smith’s BitPaint</a></li><li><a href="https://github.com/ksherlock/mpw">@ksherlock’s mpw</a></li><li><a href="https://mikeash.com/pyblog/friday-qa-2017-09-22-swift-4-weak-references.html">An explainer on Swift weak references</a></li></ul><h3>About Jordan</h3><ul><li><a href="https://twitter.com/UINT_MIN">Twitter @UINT_MIN</a></li><li><a href="https://belkadan.com">Belkadan</a></li><li><a href="https://citizensclimatelobby.org">Citizens’ Climate Lobby</a></li></ul><h3> </h3><h3>Sponsors</h3><ul><li><strong>Instabug</strong> - Get Application Performance Monitoring built for mobile apps and stay on top of your app quality with Instabug. Check them out and them them know we sent you at <a href="https://try.instabug.com/SwiftUnwrapped">https://try.instabug.com/SwiftUnwrapped</a></li></ul><p> </p><ul><li><strong>AWS Amplify </strong>- AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3> </h3><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a>.</p>
 ]]></content:encoded>
       <enclosure length="63787048" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/4eaaf04a-3e8b-4ab7-96ca-84e0f622062f/audio/92563d7e-1b47-4c64-8aa3-e04013fb02f9/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>89: Implementing the Swift Runtime in Swift, with Jordan Rose</itunes:title>
-      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:duration>01:06:22</itunes:duration>
       <itunes:summary>Today we welcome special guest, Jordan Rose to discuss implementing the Swift runtime in Swift.</itunes:summary>
       <itunes:subtitle>Today we welcome special guest, Jordan Rose to discuss implementing the Swift runtime in Swift.</itunes:subtitle>
@@ -121,13 +121,13 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <description><![CDATA[<ul><li><a href="https://swift.org/blog/5-3-release-process/">5.3 release process</a></li><li><a href="https://swift.org/blog/additional-linux-distros/">Swift for Linux distros</a></li><li><a href="https://swift.org/blog/aws-lambda-runtime/">AWS lambda Runtime</a></li><li><a href="https://swift.org/blog/swift-service-lifecycle/">Swift Service Lifecycle</a></li><li><a href="https://swift.org/blog/swift-cluster-membership/">Swift Cluster membership</a></li><li><a href="https://apple.github.io/swift-evolution/#?status=accepted&version=5.3">Proposals accepted/implemented in 5.3</a></li><li><a href="https://github.com/apple/swift/commits/release/5.3">Commit history for Swift 5.3 branch</a></li><li><a href="https://github.com/apple/swift/pull/33487">Mike Ash's perf PR</a></li><li><a href="https://www.hackingwithswift.com/articles/218/whats-new-in-swift-5-3">Hacking with Swift What’s New in Swift 5.3</a></li></ul><h2>Get in Touch</h2><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 14 Sep 2020 17:26:37 +0000</pubDate>
-      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul><li><a href="https://swift.org/blog/5-3-release-process/">5.3 release process</a></li><li><a href="https://swift.org/blog/additional-linux-distros/">Swift for Linux distros</a></li><li><a href="https://swift.org/blog/aws-lambda-runtime/">AWS lambda Runtime</a></li><li><a href="https://swift.org/blog/swift-service-lifecycle/">Swift Service Lifecycle</a></li><li><a href="https://swift.org/blog/swift-cluster-membership/">Swift Cluster membership</a></li><li><a href="https://apple.github.io/swift-evolution/#?status=accepted&version=5.3">Proposals accepted/implemented in 5.3</a></li><li><a href="https://github.com/apple/swift/commits/release/5.3">Commit history for Swift 5.3 branch</a></li><li><a href="https://github.com/apple/swift/pull/33487">Mike Ash's perf PR</a></li><li><a href="https://www.hackingwithswift.com/articles/218/whats-new-in-swift-5-3">Hacking with Swift What’s New in Swift 5.3</a></li></ul><h2>Get in Touch</h2><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
       <enclosure length="17873749" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f66e20f0-f2e0-4aef-953b-3fbf60ea8dc8/88_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>88: Swift 5.3</itunes:title>
-      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:duration>00:18:33</itunes:duration>
       <itunes:summary>Swift 5.3 will be released very soon. What should we expect?</itunes:summary>
       <itunes:subtitle>Swift 5.3 will be released very soon. What should we expect?</itunes:subtitle>
@@ -142,13 +142,13 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <description><![CDATA[<ul><li>Swift Package Index<ul><li><a href="https://iosdevweekly.com/issues/460#comment">Intro</a></li><li><a href="https://swiftpackageindex.com">Website</a></li><li><a href="https://forums.swift.org/t/introducing-the-swift-package-index/37512">Forum</a></li><li><a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server">GitHub</a></li><li><a href="https://github.com/SwiftPackageIndex/PackageList">Package List</a></li><li><a href="https://twitter.com/daveverwer">Dave</a></li><li><a href="https://twitter.com/_sa_s">Sven</a></li><li><a href="https://cocoapods.org">CocoaPods website</a></li></ul></li><li>Swift Package Registry<ul><li><a href="https://forums.swift.org/t/swift-package-registry-service/37219">Swift Package Registry Service Pitch</a><ul><li><a href="https://twitter.com/mattt/status/1278706413921951746">Tweet</a></li></ul></li><li><a href="https://forums.swift.org/t/package-manager-source-archive-dependencies/38626">Package Manager Source Archive Dependencies Pitch</a><ul><li><a href="https://twitter.com/mattt/status/1285966688597315584">Tweet</a></li></ul></li><li><a href="https://twitter.com/mattt">Mattt Thompson</a></li></ul></li></ul><h2>Get in Touch</h2><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 3 Aug 2020 12:00:06 +0000</pubDate>
-      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul><li>Swift Package Index<ul><li><a href="https://iosdevweekly.com/issues/460#comment">Intro</a></li><li><a href="https://swiftpackageindex.com">Website</a></li><li><a href="https://forums.swift.org/t/introducing-the-swift-package-index/37512">Forum</a></li><li><a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server">GitHub</a></li><li><a href="https://github.com/SwiftPackageIndex/PackageList">Package List</a></li><li><a href="https://twitter.com/daveverwer">Dave</a></li><li><a href="https://twitter.com/_sa_s">Sven</a></li><li><a href="https://cocoapods.org">CocoaPods website</a></li></ul></li><li>Swift Package Registry<ul><li><a href="https://forums.swift.org/t/swift-package-registry-service/37219">Swift Package Registry Service Pitch</a><ul><li><a href="https://twitter.com/mattt/status/1278706413921951746">Tweet</a></li></ul></li><li><a href="https://forums.swift.org/t/package-manager-source-archive-dependencies/38626">Package Manager Source Archive Dependencies Pitch</a><ul><li><a href="https://twitter.com/mattt/status/1285966688597315584">Tweet</a></li></ul></li><li><a href="https://twitter.com/mattt">Mattt Thompson</a></li></ul></li></ul><h2>Get in Touch</h2><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
       <enclosure length="34345134" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b6787f56-3a6d-43cb-884e-820a1028bba1/87_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>87: Package Registries and Indexes</itunes:title>
-      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:35:42</itunes:duration>
       <itunes:summary>There&apos;s a lot happening recently in the world of package managers, registries and indexes. Let&apos;s unwrap that.</itunes:summary>
@@ -164,13 +164,13 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <description><![CDATA[<h4>SE-0282 Tuples conform to Equatable, Comparable, and Hashable</h4><ul><li>Acceptance: <a href="https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658">https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658</a></li><li>Review: <a href="https://forums.swift.org/t/se-0283-tuples-conform-to-equatable-comparable-and-hashable/36140">https://forums.swift.org/t/se-0283-tuples-conform-to-equatable-comparable-and-hashable/36140</a></li><li>Proposal: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0283-tuples-are-equatable-comparable-hashable.md">https://github.com/apple/swift-evolution/blob/master/proposals/0283-tuples-are-equatable-comparable-hashable.md</a></li></ul><p>Bow: <a href="https://bow-swift.io">https://bow-swift.io</a></p><h3>👋 Get in Touch</h3><p>We are <a href="https://twitter.com/swift_unwrapped">@swift_unwrapped</a> on twitter. Follow us, ask us a question, let us know what you think of the show! If you want to follow us individually, we're <a href="https://twitter.com/jesse_squires">@jesse_squires</a> and <a href="https://twitter.com/simjp">@simjp</a>.</p><h3>🖤 Leave A Review</h3><p>If you're enjoying the show. The best and easiest way to show your support is by heading over to iTunes and leaving us a review! Not only do you let us know what you like about the show, but you're also helping other Swift language folks find the show.</p><p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
 ]]></description>
       <pubDate>Thu, 18 Jun 2020 12:00:04 +0000</pubDate>
-      <author>shows@spec.fm (Spec Network, Inc.)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h4>SE-0282 Tuples conform to Equatable, Comparable, and Hashable</h4><ul><li>Acceptance: <a href="https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658">https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658</a></li><li>Review: <a href="https://forums.swift.org/t/se-0283-tuples-conform-to-equatable-comparable-and-hashable/36140">https://forums.swift.org/t/se-0283-tuples-conform-to-equatable-comparable-and-hashable/36140</a></li><li>Proposal: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0283-tuples-are-equatable-comparable-hashable.md">https://github.com/apple/swift-evolution/blob/master/proposals/0283-tuples-are-equatable-comparable-hashable.md</a></li></ul><p>Bow: <a href="https://bow-swift.io">https://bow-swift.io</a></p><h3>👋 Get in Touch</h3><p>We are <a href="https://twitter.com/swift_unwrapped">@swift_unwrapped</a> on twitter. Follow us, ask us a question, let us know what you think of the show! If you want to follow us individually, we're <a href="https://twitter.com/jesse_squires">@jesse_squires</a> and <a href="https://twitter.com/simjp">@simjp</a>.</p><h3>🖤 Leave A Review</h3><p>If you're enjoying the show. The best and easiest way to show your support is by heading over to iTunes and leaving us a review! Not only do you let us know what you like about the show, but you're also helping other Swift language folks find the show.</p><p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
 ]]></content:encoded>
       <enclosure length="38973156" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/641073f1-f00c-4303-b83d-140a78ceab87/project-86v2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>86: Tuples</itunes:title>
-      <itunes:author>Spec Network, Inc.</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:40:32</itunes:duration>
       <itunes:summary>Is it pronounced &quot;Tuple&quot; or &quot;Tuple&quot;?</itunes:summary>
@@ -200,7 +200,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
 ]]></description>
       <pubDate>Tue, 3 Mar 2020 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Foundation on Windows: https://forums.swift.org/t/swift-soars-ever-higher/34036</li>
@@ -220,7 +220,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="12276069" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8f254c9e-ffbc-438c-850e-2c09480eb5a5/85-swiftonwindowsv2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>85: Swift on Windows and other news</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:25:26</itunes:duration>
       <itunes:summary>Swift Foundation is now building on Windows and passing all tests, interop with C++ is being discussed on the forums, and new Swift libraries are available.</itunes:summary>
@@ -250,7 +250,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
 ]]></description>
       <pubDate>Mon, 3 Feb 2020 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Magic file names: https://github.com/apple/swift-evolution/blob/master/proposals/0274-magic-file.md</li>
@@ -270,7 +270,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="31512580" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/34c97512-6201-477a-a478-b74d6ac2a7fd/84-swiftworldtour_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>84: Swift World Tour 2020</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:32:45</itunes:duration>
       <itunes:summary>We discuss recent news, evolution proposals, and Swift 6</itunes:summary>
@@ -293,7 +293,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 6 Jan 2020 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><a href="https://forums.swift.org/t/modify-accessors/31872">Forum post</a></li>
@@ -306,7 +306,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="30742914" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/94ee22bc-9244-4aea-9145-d1b776f3888e/83-modifyaccessors_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>83: Modify Accessors</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:31:54</itunes:duration>
       <itunes:summary>We discuss a recent Swift Evolution pitch from Ben Cohen on Modify Accessors.</itunes:summary>
@@ -335,7 +335,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 2 Dec 2019 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>The way Swift reports compilation diagnostics like errors, warnings and fixits is about to improve in Swift 5.2.</p>
 <ul>
@@ -354,7 +354,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="34621040" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/2c2ea7b8-9cd0-45ff-bae2-966977d4ab74/82_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>82: Swift&apos;s New Diagnostic Architecture</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:36:00</itunes:duration>
       <itunes:summary>The way Swift reports compilation diagnostics like errors, warnings and fixits is about to improve in Swift 5.2.</itunes:summary>
@@ -385,7 +385,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 4 Nov 2019 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Would you like some Swift in your Swift? The compiler driver is getting a shiny new implementation in Swift and there's no shortage of opportunities to contribute.</p>
 <ul>
@@ -406,7 +406,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="25413788" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5136fbe5-9c97-4779-a22b-6fe5b2961229/81_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>81: Swift Compiler Driver</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:24</itunes:duration>
       <itunes:summary>Would you like some Swift in your Swift? The compiler driver is getting a shiny new implementation in Swift and there&apos;s no shortage of opportunities to contribute.</itunes:summary>
@@ -437,7 +437,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 7 Oct 2019 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>The Swift of tomorrow... today! The Standard Library Preview Package would allow you to try out upcoming Swift features before they officially ship with new language versions.</p>
 <ul>
@@ -458,7 +458,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="28708165" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/9e3c7017-37a3-4f34-9f94-c4cbccc1871c/80_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>80: Standard Library Preview Package</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:29:50</itunes:duration>
       <itunes:summary>The Swift of tomorrow... today! The Standard Library Preview Package would allow you to try out upcoming Swift features before they officially ship with new language versions.</itunes:summary>
@@ -486,7 +486,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 16 Sep 2019 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Burritos: https://github.com/guillermomuntaner/Burritos</li>
@@ -504,7 +504,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="50234723" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e4296fcf-b739-4226-9cdd-1cdaf34bae5c/79_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>79: Swift 5.1 with Doug Gregor</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:52:16</itunes:duration>
       <itunes:summary>We invite special guest, Doug Gregor, back to the show to discuss all things Swift 5.1</itunes:summary>
@@ -532,7 +532,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 2 Sep 2019 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Forum pitch: https://forums.swift.org/t/pitch-support-for-binary-dependencies/27620</li>
@@ -550,7 +550,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="28831488" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e3a1605d-aa61-483c-b135-dd39c75bc077/78_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>78: Binary Dependencies in Swift Package Manager</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:29:58</itunes:duration>
       <itunes:summary>What&apos;s one feature missing from the Swift Package Manager that CocoaPods has had for years? Binary dependencies! But how would this work in SPM?</itunes:summary>
@@ -581,7 +581,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 5 Aug 2019 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0246-mathable.md">Proposal SE-0246</a></li>
@@ -602,7 +602,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="24446216" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a6992481-1ec7-4d05-a4d2-1d57cd6f520a/77_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>77: Generic Math Functions and Approximate Equality</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:25:24</itunes:duration>
       <itunes:summary>We discuss the new generic math functions coming to Swift, as well as approximate equality for floating point numbers.</itunes:summary>
@@ -641,7 +641,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 1 Jul 2019 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md">Proposal SE-0258</a></li>
@@ -670,7 +670,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="30380815" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/234e904c-9511-47ee-9fa8-658b58c60878/76_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>76: Property Wrappers</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:31:34</itunes:duration>
       <itunes:summary>A concept that&apos;s been in and out of conversation for Swift since 2015, property behaviors - uh, delegates - uh, wrappers - are now back with the full weight of SwiftUI behind it.</itunes:summary>
@@ -706,7 +706,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Sun, 2 Jun 2019 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>Links</h2>
 <ul>
@@ -732,7 +732,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="26943019" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/bad49a09-7e7d-442f-984f-3234da02fa5a/75-build-systems-w-keith-smiley_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>75: Swift Build Systems w/ Keith Smiley</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:27:59</itunes:duration>
       <itunes:summary>In this episode with special guest Keith Smiley, we cover the growing number of  tools that let you build things in Swift, a few of which are made by Apple, as well as some others like CMake, Bazel and Buck.</itunes:summary>
@@ -770,7 +770,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 6 May 2019 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>Relevant Links</h2>
 <ul>
@@ -798,7 +798,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="33463274" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/6a1f3e80-2343-4c5e-ac0e-53a8ceea62b5/74_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>74: Removing Things From Swift</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:34:47</itunes:duration>
       <itunes:summary>Although we usually discuss new features being added to Swift, this episode is all about removing things from the language.</itunes:summary>
@@ -832,7 +832,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 1 Apr 2019 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>Relevant Links</h2>
 <ul>
@@ -856,7 +856,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="25377849" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7e3b0edd-7187-4200-93a7-fb04b40598cf/project-73_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>73: UTF-8 Strings in Swift 5</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:22</itunes:duration>
       <itunes:summary></itunes:summary>
@@ -895,7 +895,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 4 Mar 2019 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>Relevant Links</h2>
 <ul>
@@ -924,7 +924,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="38831987" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/187ac56a-0044-47bb-bd37-cf08d274ae77/72-official-styleguide-and-formatter_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>72: Pitch for Official Style Guide &amp; Formatter for Swift</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:40:22</itunes:duration>
       <itunes:summary>In what is sure to lead to significant community discussion, there&apos;s now a pitch for adding a style guide and formatter to Swift.
@@ -966,7 +966,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 4 Feb 2019 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>Relevant Links</h2>
 <ul>
@@ -996,7 +996,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="27475088" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b06bf92c-00f5-48d3-bb43-b3eaae14c4fd/71-key-path-expressions-as-functional-dependencies_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>71: Key Path Expressions as Functions</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:28:33</itunes:duration>
       <itunes:summary>If this proposal is accepted, we&apos;ll be seeing Key Paths in a lot more places.</itunes:summary>
@@ -1031,7 +1031,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 7 Jan 2019 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>Relevant Links</h2>
 <ul>
@@ -1056,7 +1056,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="19523053" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8cdd945e-9641-42a4-a8ba-7b79fc8f3404/70-sourcekit-lsp_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>70: SourceKit-LSP</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:20:16</itunes:duration>
       <itunes:summary>The Swift project is working on official support for the industry-standard Language Server Protocol and we can barely contain our excitement.</itunes:summary>
@@ -1081,7 +1081,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 3 Dec 2018 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md">Proposal</a></li>
@@ -1096,7 +1096,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="24471594" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/43ae0c67-df77-48fb-8591-b7595e53661e/69-proposal-to-add-restult_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>69: Result</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:25:25</itunes:duration>
       <itunes:summary>It&apos;s the most wonderful time of the year again... the time when the Swift community considers adding a Result type to the standard library. Except that this time it&apos;ll probably work!</itunes:summary>
@@ -1121,7 +1121,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Now, Swift Unwrapped listeners will get a free t-shirt when they sign up at <a href="https://instabug.com/swift">https://instabug.com/swift</a>.</p>
 ]]></description>
       <pubDate>Mon, 5 Nov 2018 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://forums.swift.org/t/opaque-result-types/15645</li>
@@ -1136,7 +1136,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="15809542" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/033cae49-ad27-456e-b678-c2c062191461/68-opaque-result-types_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>68: Opaque Result Types</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:16:24</itunes:duration>
       <itunes:summary>In this episode, Jesse and JP dive in to opaque result types, which could help prevent leaking of implementation details to library consumers.</itunes:summary>
@@ -1164,7 +1164,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Now, Swift Unwrapped listeners will get a free t-shirt when they sign up at <a href="https://instabug.com/swift">https://instabug.com/swift</a>.</p>
 ]]></description>
       <pubDate>Mon, 15 Oct 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0200-raw-string-escaping.md">SE-0200 Enhancing String Literals Delimiters to Support Raw Text</a></li>
@@ -1182,7 +1182,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="27169628" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/41fe97d1-9d3e-43a5-9691-25bdd82c0779/67-raw-string_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>67: Raw Strings</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:28:14</itunes:duration>
       <itunes:summary>String literals are the gift that keep on giving with each Swift version, and Swift 5 is no exception, with raw strings.</itunes:summary>
@@ -1206,7 +1206,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Now, Swift Unwrapped listeners will get a free t-shirt when they sign up at <a href="https://instabug.com/swift">https://instabug.com/swift</a>.</p>
 ]]></description>
       <pubDate>Mon, 20 Aug 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://forums.swift.org/t/plan-for-module-stability/14551</li>
@@ -1220,7 +1220,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="32794939" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8ba0546f-7f40-4469-a211-1027b5ac86e2/project-66_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>66: Plan For Module Stability</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:34:06</itunes:duration>
       <itunes:summary>We discuss Jordan Rose&apos;s recent forums post on a proposed plan for module stability.</itunes:summary>
@@ -1243,7 +1243,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 2 Jul 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0213-literal-init-via-coercion.md">SE-0213: Literal initialization via coercion</a></li>
@@ -1256,7 +1256,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="9516326" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a79347e7-d080-48db-9e7a-dec3f1426db5/65-literal-initialization-via-coercion_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>65: Literal Initialization Via Coercion</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:09:50</itunes:duration>
       <itunes:summary>A recent type checking speedup had very small source compatibility breakages, but nonetheless went through the evolution process and it was accepted!</itunes:summary>
@@ -1280,7 +1280,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 25 Jun 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><code>Never</code> &amp; <code>absurd()</code>: https://twitter.com/pteasima/status/978325590397906944</li>
@@ -1294,7 +1294,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="30937092" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f7b9fbd4-a09e-4457-9abe-39458e2dcebe/64-never_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>64: Never</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:32:09</itunes:duration>
       <itunes:summary>The Never type has some very unique properties and behavior. We introduce the type and discuss a recent proposal (SE-215) to make it conform to Hashable and Equatable.</itunes:summary>
@@ -1320,7 +1320,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 ]]></description>
       <pubDate>Mon, 18 Jun 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Data Structures and Algorithms in Swift: https://store.raywenderlich.com/products/data-structures-and-algorithms-in-swift</li>
@@ -1336,7 +1336,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="43470224" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5dcadaf5-0987-4564-9ed9-c21e5e94dcbf/61-swift-algorithms-and-data-structures-with-kelvin-lau-and-vincent-ngo_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>63: Swift algorithms and data structures (feat. Kelvin Lau &amp; Vincent Ngo)</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:45:12</itunes:duration>
       <itunes:summary>We welcome Kelvin and Vincent to the show to discuss Data Structures and Algorithms in Swift.</itunes:summary>
@@ -1358,7 +1358,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 ]]></description>
       <pubDate>Wed, 13 Jun 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Ted Kremenek on Twitter: https://twitter.com/tkremenek</li>
@@ -1370,7 +1370,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="47236284" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e58dbe9c-430e-48e5-8444-65f5d2da5100/ted-kremenek_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>62: Interview with Ted Kremenek</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:49:08</itunes:duration>
       <itunes:summary>An in-depth conversation about Swift 4.2 and beyond with Ted Kremenek, Manager of the Languages and Runtimes team at Apple.</itunes:summary>
@@ -1396,7 +1396,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 ]]></description>
       <pubDate>Mon, 11 Jun 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>This episode is a little different, where we discuss general announcements from WWDC 2018 not just limited to the Swift language. With special guest Greg Heo.</p>
 <ul>
@@ -1412,7 +1412,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="41929152" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4420cdd7-d9ec-4285-b5fe-6811040df5c8/61-greg-heo-swiftunwrapped_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>61: WWDC reactions with Greg Heo</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:43:36</itunes:duration>
       <itunes:summary>We discuss the announcements from WWDC 2018 with special guest, Greg Heo.</itunes:summary>
@@ -1442,7 +1442,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 ]]></description>
       <pubDate>Mon, 28 May 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Forums:</p>
 <ul>
@@ -1462,7 +1462,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="17403646" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/ec245c2f-8cc8-45ee-ac90-c66da8811a30/60-character-properties_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>60: Character Properties</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:18:03</itunes:duration>
       <itunes:summary>We discuss recent proposals on adding unicode properties to characters and Unicode.scalar.</itunes:summary>
@@ -1488,7 +1488,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Check them out, use that promo code and get 20% off at <a href="https://instabug.com/swift">https://instabug.com/swift</a></p>
 ]]></description>
       <pubDate>Mon, 21 May 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>Links</h3>
 <ul>
@@ -1504,7 +1504,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="23458019" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/9d7fa712-39ad-457a-b090-ff4deabe88a2/59-escaping-closures_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>59: Implicit Escaping of Closures</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:24:22</itunes:duration>
       <itunes:summary>Escaping or non-escaping? That is the question.</itunes:summary>
@@ -1531,7 +1531,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 14 May 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Blog post on Reimplementation of Implicitly Unwrapped Optionals: https://swift.org/blog/iuo</li>
@@ -1548,7 +1548,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="15924548" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/642a1037-d1c2-47a5-9d34-5e0abcb68a77/58-reimplementation-of-implicitly-unwrapped-optionals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>58: Reimplementation of Implicitly Unwrapped Optionals</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:16:31</itunes:duration>
       <itunes:summary>IUOs are dead, long live IUOs! With this change, IUOs are no longer a type but rather a special variant of Optional.</itunes:summary>
@@ -1581,7 +1581,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 7 May 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://github.com/tensorflow/swift/blob/master/docs/DesignOverview.md</li>
@@ -1604,7 +1604,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="39065281" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d987c101-6a78-4ae8-80c7-295b7ca5fad8/57-revisiting-tensorflow_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>57: Swift for TensorFlow Design Overview</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:40:37</itunes:duration>
       <itunes:summary>Now that Swift for TensorFlow has been open sourced and documentation is available, we share some very interesting findings.</itunes:summary>
@@ -1629,7 +1629,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 30 Apr 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0206-hashable-enhancements.md</li>
@@ -1644,7 +1644,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="18527126" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5c213281-9104-498d-be10-d15b64a7b59f/56-se-206-hashable-enhancements_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>56: SE-206 Hashable Enhancements</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:19:13</itunes:duration>
       <itunes:summary>Swift will soon have a more robust hashing strategy, and it doesn&apos;t involve always returning zero for hashValue.</itunes:summary>
@@ -1671,7 +1671,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 23 Apr 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0202-random-unification.md</li>
@@ -1688,7 +1688,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="23395003" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/da8a81c5-cf62-46b1-a7c9-1bd1e5844933/55-se-202-random-unification_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>55: SE-202 Random Unification</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:24:18</itunes:duration>
       <itunes:summary>Randomness gets a long overdue Swift treatment.</itunes:summary>
@@ -1714,7 +1714,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></description>
       <pubDate>Mon, 16 Apr 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://github.com/apple/swift-evolution/blob/master/proposals/0197-remove-where.md</li>
@@ -1730,7 +1730,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="22850920" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b6a3fd5d-8692-48cc-a41b-752782516396/54-collection-sequence-proposals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>54: Collection &amp; Sequence Proposals</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:23:44</itunes:duration>
       <itunes:summary>We cover a few recent Collection &amp; Sequence Swift Evolution proposals.</itunes:summary>
@@ -1755,7 +1755,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Check them out and let them know we sent you at <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w15">Bitrise.io</a></p>
 ]]></description>
       <pubDate>Mon, 9 Apr 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://www.tensorflow.org/</li>
@@ -1770,7 +1770,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="20855561" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/699546bf-f16a-49ed-bb6a-079ef994eb9d/53-swift-for-tensorflow_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>53: Swift for TensorFlow</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:21:39</itunes:duration>
       <itunes:summary>It happened. Google forked Swift. Swift for Tensorflow has wide-reaching implications and we just had to share our thoughts.</itunes:summary>
@@ -1793,7 +1793,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Thanks to this episode's sponsor, <a href="https://kobiton.com/swift/?utm_source=Swift_Unwrapped_Podcast&amp;utm_medium=Podcast&amp;utm_campaign=3.20_Swift_Unwrapped_Podcast&amp;utm_content=Free_iPhone_X">Kobiton</a>. Go to <a href="https://kobiton.com/swift/?utm_source=Swift_Unwrapped_Podcast&amp;utm_medium=Podcast&amp;utm_campaign=3.20_Swift_Unwrapped_Podcast&amp;utm_content=Free_iPhone_X">Kobiton.com/swift</a> and get your extra trial minutes!</p>
 ]]></description>
       <pubDate>Mon, 2 Apr 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>We cover two recent Swift Package Manager proposal pitches.</p>
 <ul>
@@ -1806,7 +1806,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="21807266" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/60121283-ed97-4b30-92e1-934aaa46a06f/52_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>52: Package Manager Proposals</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:22:38</itunes:duration>
       <itunes:summary>We cover two recent Swift Package Manager proposal pitches.</itunes:summary>
@@ -1831,7 +1831,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 26 Mar 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Conditional conformance: https://swift.org/blog/conditional-conformance/</li>
@@ -1846,7 +1846,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="30822268" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b0d0ed63-d512-4910-8a6d-9ad8670be908/51-doug-and-ben-part-2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>51: Swift 4.1 w/ Doug &amp; Ben (part 2)</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:32:02</itunes:duration>
       <itunes:summary>We go over the Swift 4.1 release highlights with Ben Cohen and Doug Gregor from the Swift team. Part 2 of 2.</itunes:summary>
@@ -1871,7 +1871,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 19 Mar 2018 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Conditional conformance: https://swift.org/blog/conditional-conformance/</li>
@@ -1886,7 +1886,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="18147541" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/c9bed05a-df75-499f-b04c-b27aec4d8e84/50-doug-and-ben-part-1_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>50: Swift 4.1 w/ Doug &amp; Ben (part 1)</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:18:50</itunes:duration>
       <itunes:summary>We go over the Swift 4.1 release highlights with Ben Cohen and Doug Gregor from the Swift team. Part 1 of 2.</itunes:summary>
@@ -1907,7 +1907,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 ]]></description>
       <pubDate>Mon, 5 Mar 2018 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>In Today's episode we share thoughts on Dave DeLong's &quot;protocol wishlist&quot; for Swift and other ideas for improving Swift's protocols.</p>
 <ul>
@@ -1918,7 +1918,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="34113985" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/eedb656b-9197-47aa-b979-f53b4770bb04/49-swift-unwrapped-protocols-wishlist_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>49: Swift Protocol Wishlist</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:47:17</itunes:duration>
       <itunes:summary>Thoughts on Dave DeLong&apos;s &quot;protocol wishlist&quot; for Swift and other ideas for improving Swift&apos;s protocols.</itunes:summary>
@@ -1940,7 +1940,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 ]]></description>
       <pubDate>Mon, 26 Feb 2018 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Announcement on Swift Forums: https://forums.swift.org/t/swift-to-participate-in-gsoc-2018/10147</li>
@@ -1952,7 +1952,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="32448949" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/be309391-e715-4edf-a57f-4feb95fd5858/48-googlesummerofcode_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>48: Google Summer Of Code 2018</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:33:44</itunes:duration>
       <itunes:summary>Swift.org is officially participating in the Google Summer of Code program, and there are some great project ideas.</itunes:summary>
@@ -1981,7 +1981,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 ]]></description>
       <pubDate>Mon, 19 Feb 2018 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>
@@ -2000,7 +2000,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="19570846" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/2a5c9ab9-ecd1-4211-a3b1-569ccf7775e0/47-revamp-playgrounds_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>47: Revamping QuickLook Playground APIs</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:20:19</itunes:duration>
       <itunes:summary>We discuss Connor Wakamo&apos;s proposal to revamp the Playground QuickLook APIs</itunes:summary>
@@ -2029,7 +2029,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 ]]></description>
       <pubDate>Mon, 12 Feb 2018 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>
@@ -2048,7 +2048,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="14696554" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f3757aca-5b46-47a1-9135-a162dd64c141/46-new-proposals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>46: Restricting cross-module struct initializers</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:15:14</itunes:duration>
       <itunes:summary>We discuss Jordan Rose&apos;s proposal to address issues with struct initializers</itunes:summary>
@@ -2084,7 +2084,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 5 Feb 2018 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li><code>Sequence.split</code> should have a Lazy equivalent: <a href="https://bugs.swift.org/browse/SR-6691">SR-6691</a></li>
@@ -2110,7 +2110,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="25112089" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/225c62f6-62e0-4424-bad7-dd230e0b831a/45-recent-news_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>45: Swift News January 2018</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:05</itunes:duration>
       <itunes:summary>The pace is picking up early 2018, so there&apos;s a lot to cover.</itunes:summary>
@@ -2130,7 +2130,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 29 Jan 2018 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://www.jessesquires.com/blog/swift-weekly-brief-hiatus/</li>
@@ -2140,7 +2140,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="11442722" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/88f0889d-a510-44c4-ab0f-559355cf98c2/44-swift-weekly-brief_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>44: Swift Bi-Weekly Brief</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:11:51</itunes:duration>
       <itunes:summary>The King is dead, long live the King!</itunes:summary>
@@ -2161,7 +2161,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 22 Jan 2018 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>State of String: ABI, Performance, Ergonomics, and You! https://gist.github.com/milseman/bb39ef7f170641ae52c13600a512782f</li>
@@ -2172,7 +2172,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="23289325" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d4cf620f-3176-479f-bc09-cbcdc8b650db/43-stateofstring_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>43: State of String</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:24:11</itunes:duration>
       <itunes:summary>We dissect Michael Ilseman&apos;s recent document with potential optimizations and improvements to String in preparation for ABI stability.</itunes:summary>
@@ -2198,7 +2198,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 15 Jan 2018 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Swift 4.1 will include support for conditional protocol conformance, and we're excited to use it!</p>
 <ul>
@@ -2214,7 +2214,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="13334811" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7ac06d5e-4a1d-4a81-a03d-b486d4b40223/42-roadmaping_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>42: Conditional Conformance</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:13:49</itunes:duration>
       <itunes:summary>Swift 4.1 will include support for conditional protocol conformance, and we&apos;re excited to use it!</itunes:summary>
@@ -2235,7 +2235,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 8 Jan 2018 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Graydon Hoare’s swift-dev email: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20171113/006001.html</li>
@@ -2246,7 +2246,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="22725539" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d3ee70a2-1165-4329-8998-b82296006fe0/41-improving-performance_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>41: Improving Compilation Performance</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:23:36</itunes:duration>
       <itunes:summary>We discuss the recent efforts improving &amp; instrumenting the Swift compiler&apos;s performance.</itunes:summary>
@@ -2278,7 +2278,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 18 Dec 2017 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Introduce User-defined &quot;Dynamic Member Lookup&quot; Types:
@@ -2300,7 +2300,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="20788733" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8a89de6b-42e8-4fde-b723-1d284960eb75/40-dynamic-number-lookup-proposal_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>40: Dynamic Member Lookup Proposal</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:21:35</itunes:duration>
       <itunes:summary>We discuss Chris Lattner&apos;s recent &quot;Dynamic Member Lookup&quot; proposal.</itunes:summary>
@@ -2322,7 +2322,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 11 Dec 2017 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://bugs.swift.org/browse/SR-4981</li>
@@ -2334,7 +2334,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="25085608" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3e80f055-47d1-4a5f-a17c-46daae9e28fc/39-swift-source-compatibility-suite_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>39: Source Compatibility Suite Woes</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:03</itunes:duration>
       <itunes:summary>The source compatibility suite has been useful in catching compatibility issues before official Swift releases are cut, but it leaves much to be desired especially around communication with project maintainers outside Apple.</itunes:summary>
@@ -2364,7 +2364,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 4 Dec 2017 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Enable core dumps: <code>ulimit -c unlimited</code></li>
@@ -2384,7 +2384,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="22720383" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3b3a3df2-823c-44f1-a729-b71332353d91/38-data-bases-concurrency-threading_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>38: Off to the Races</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:23:35</itunes:duration>
       <itunes:summary>Think thread safety with Swift is the same as C languages, with slightly different syntax? Think again!</itunes:summary>
@@ -2406,7 +2406,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 27 Nov 2017 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Original proposal: https://github.com/apple/swift-evolution/pull/114</li>
@@ -2418,7 +2418,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="22068053" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0c2522ea-b3c8-4d72-a96b-653fdee6a484/37-enum-case-enumerable-proposal_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>37: Enum Case Enumerable Proposal</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:22:55</itunes:duration>
       <itunes:summary>Enumerate. All. The. Cases.</itunes:summary>
@@ -2444,7 +2444,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 ]]></description>
       <pubDate>Mon, 13 Nov 2017 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Float80 Corrections: https://mobile.twitter.com/daniel_dunbar/status/923694549238611970</li>
@@ -2460,7 +2460,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="19230976" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3ff00000-92a9-44e0-9f7a-f19dc57e3162/36-swift-evolution-topics_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>36: Swift Evolution - Current Topics &amp; Proposals</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:19:57</itunes:duration>
       <itunes:summary>Brief discussion around some recent proposals.</itunes:summary>
@@ -2491,7 +2491,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 30 Oct 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>JP's FrenchKit talk on &quot;Performance Profiling Swift on Linux&quot;:
@@ -2512,7 +2512,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="32007984" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/da4542a6-eb11-4838-b2e6-aec756244292/35-performance-profiling-on-linux_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>35: Performance Profiling on Linux</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:33:16</itunes:duration>
       <itunes:summary>How do you even profile without Instruments.app?</itunes:summary>
@@ -2535,7 +2535,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 23 Oct 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://www.jessesquires.com/blog/floating-point-swift-ulp-and-epsilon/</li>
@@ -2548,7 +2548,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="21278522" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f00dfd79-3a7e-46aa-9ac5-d0147cf8597e/34-floating-point_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>34: Floating-Point</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:22:05</itunes:duration>
       <itunes:summary>We discuss Swift’s numeric protocols and types, especially those of the floating point variety.</itunes:summary>
@@ -2586,7 +2586,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 16 Oct 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Server APIs Project: https://swift.org/server-apis/</li>
@@ -2614,7 +2614,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="18088665" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b535714c-2b4b-4d7e-88d8-d0bb05e85431/33-http_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>33: HTTP server v0.1.0</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:18:46</itunes:duration>
       <itunes:summary>We discuss the first release of the HTTP server library from the Swift Server APIs project.</itunes:summary>
@@ -2639,7 +2639,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 9 Oct 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>https://swift.org/migration-guide-swift4/</li>
@@ -2654,7 +2654,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="21464943" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7ba08528-4152-4f09-a9f3-22e7beb20dab/32-migratingtoswift4_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>32: Migrating to Swift 4</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:22:17</itunes:duration>
       <itunes:summary>Since many of you are probably migrating to Swift 4 as you listen to this, we figured we&apos;d share our thoughts on the transition.</itunes:summary>
@@ -2689,7 +2689,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're ready for free a continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams - give them a try at <a href="https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped">buddybuild.com</a> and let them know we sent you!</p>
 ]]></description>
       <pubDate>Mon, 2 Oct 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Measuring Swift compile times in Xcode 9: https://www.jessesquires.com/blog/measuring-compile-times-xcode9/</li>
@@ -2714,7 +2714,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 ]]></content:encoded>
       <enclosure length="24146990" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/319089de-aa5f-4d6c-892b-024e060eea48/31-compiletime_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>31: Compile Times</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:25:05</itunes:duration>
       <itunes:summary>We share our tips for measuring &amp; improving Swift compilation times, as well as share some news about recent efforts to test compile times within the Swift repo.</itunes:summary>
@@ -2735,7 +2735,7 @@ https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2</p>
 http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></description>
       <pubDate>Mon, 25 Sep 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Friday Q&amp;A:<br />
 https://mikeash.com/pyblog/friday-qa-2017-09-22-swift-4-weak-references.html</p>
@@ -2746,7 +2746,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="30301872" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/ce4dca05-3f4f-4c2d-8e41-8e5ded7eee7c/30-weak-references-mike-ash_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>30: Weak References with Mike Ash</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:31:29</itunes:duration>
       <itunes:summary>We welcome Mike Ash to the show to discuss the implementation details of weak references in Swift and how they&apos;ve changed.</itunes:summary>
@@ -2769,7 +2769,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 18 Sep 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>iPhone X keynote + GM seeds for Xcode 9, Swift 4</li>
@@ -2782,7 +2782,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="31753901" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d6039571-6970-4994-b8d9-75d73748aa26/29-technology_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>29: Notes from Ted Kremenek, Recent Proposals &amp; Xcode 9 GM</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:33:00</itunes:duration>
       <itunes:summary>We discuss some recent Swift Evolution proposals, Xcode 9 GM, along with a boatload of Follow Up (tm) from Ted Kremenek and Pierre Habouzit.</itunes:summary>
@@ -2812,7 +2812,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Thanks to BuddyBuild for sponsoring this episode: https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped</p>
 ]]></description>
       <pubDate>Mon, 11 Sep 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Swift.org blog post on Swift Local Refactoring: https://swift.org/blog/swift-local-refactoring/</li>
@@ -2832,7 +2832,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="31734595" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/942f3e25-a7d6-4dbf-8b62-3326253070ba/28-refactoring-engine_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>28: Refactoring Engine</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:32:59</itunes:duration>
       <itunes:summary>All about the recent refactoring pieces announced at WWDC 2017 and open sourced in the last few months.</itunes:summary>
@@ -2871,7 +2871,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 4 Sep 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Please take a minute to leave <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203">a review on iTunes</a> and <a href="http://spectrum.chat/specfm/swift-unwrapped">join us on Spectrum chat</a> if you'd like to discuss the show.</p>
 <ul>
@@ -2900,7 +2900,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="57295173" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/af11f028-e749-46e7-915d-1a2d1529b939/27-chris-lattner_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>27: Concurrency with Chris Lattner</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:59:36</itunes:duration>
       <itunes:summary>We welcome Chris Lattner to the show to discuss concurrency in Swift 5 and beyond!</itunes:summary>
@@ -2920,7 +2920,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
 ]]></description>
       <pubDate>Mon, 28 Aug 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Mailing List: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170807/038645.html</li>
@@ -2930,7 +2930,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="33417241" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b307fe79-65a0-4293-a524-d0e5e89d123c/26-swift5_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>26: Swift 5 Goals</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:34:44</itunes:duration>
       <itunes:summary>We share our thoughts on the newly announced goals for Swift 5.</itunes:summary>
@@ -2951,7 +2951,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
 ]]></description>
       <pubDate>Mon, 21 Aug 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
@@ -2962,7 +2962,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="25114944" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5b31a287-ea14-436c-8d8d-4516731b2661/25-abi-stability-calling-convention-runtime-and-standard-library_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>25: ABI Stability –  Calling Convention, Runtime and Standard Library</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:05</itunes:duration>
       <itunes:summary>The fourth and final episode in our series on ABI Stability, we cover the remaining categories of decisions that must be made to stabilize the ABI.</itunes:summary>
@@ -2985,7 +2985,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
 ]]></description>
       <pubDate>Mon, 14 Aug 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Twitter thread on source stability discussion for episode 22: https://twitter.com/swift_unwrapped/status/892023116377075712</li>
@@ -2998,7 +2998,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="32570478" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/bdc44b4f-6b68-4c2f-bfed-a61b1b8dfc93/24-abi-stability-mangling_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>24: ABI Stability - Mangling</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:33:51</itunes:duration>
       <itunes:summary>Continuing our series on ABI Stability with a third installment, we focus on the mangling component and address some past mistakes.</itunes:summary>
@@ -3027,7 +3027,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Thanks to this episode's sponsor, <a href="https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped">Buddy Build</a>: a continuous integration, continuous deployment and user feedback platform built specifically for mobile development teams. Try it out today FREE: https://www.buddybuild.com</p>
 ]]></description>
       <pubDate>Mon, 7 Aug 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
@@ -3046,7 +3046,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="36135284" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/64f4054e-fe7f-407a-90e9-54c1b42afa65/23-abi-data-layout_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>23: ABI Stability – Data Layout and Metadata</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:37:34</itunes:duration>
       <itunes:summary>Following last week&apos;s episode on the big picture of ABI Stability, we focus on two categories of decisions that need to happen to get there: data layout and metadata.</itunes:summary>
@@ -3066,7 +3066,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 31 Jul 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>ABI Stability Manifesto: https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md</li>
@@ -3076,7 +3076,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="36902185" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/96281bdf-d8a7-42b6-adc1-4d6cdc3ad58a/22-abi-stability_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>22: ABI Stability – The Big Picture</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:38:22</itunes:duration>
       <itunes:summary>We clear up some of the misconceptions around what ABI stability means, how we&apos;ll get there and why it&apos;s important.</itunes:summary>
@@ -3098,7 +3098,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 24 Jul 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Bug of the week (sandboxing!): <a href="https://bugs.swift.org/browse/SR-5491">SR-549</a>, <a href="https://bugs.swift.org/browse/SR-5061">SR-5061</a></li>
@@ -3110,7 +3110,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="26235023" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0420d3d2-6780-4313-a5b2-a77b6732d4eb/21-newproposals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>21: New Proposals</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:27:15</itunes:duration>
       <itunes:summary>This week we dive into some of the recent proposals, including SE-0180, SE-0181, SE-0182, SE-0183</itunes:summary>
@@ -3131,7 +3131,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 17 Jul 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Bug of the week: https://bugs.swift.org/browse/SR-4088</li>
@@ -3142,7 +3142,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="28326384" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/6bd2a1e4-241b-40fb-9bb2-c3c5fe470fb3/20-swift-migrator_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>20: Swift Migrator</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:29:26</itunes:duration>
       <itunes:summary>We dissect the newly open sourced part of Swift tooling that helps us port our apps to the latest Swift version.</itunes:summary>
@@ -3164,7 +3164,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 10 Jul 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Improvement of the week: https://github.com/apple/swift-package-manager/pull/1249</li>
@@ -3176,7 +3176,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="30979470" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0cc3b9b4-fe77-4261-8b07-7121aa70d8fa/22_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>19: WWDC Reactions</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:42:56</itunes:duration>
       <itunes:summary>A month after WWDC, we share our thoughts on the announcements and events from the week.</itunes:summary>
@@ -3204,7 +3204,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 3 Jul 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>SipHash: https://github.com/lorentey/SipHash</li>
@@ -3222,7 +3222,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="36266469" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4e4a91d7-9e9c-45be-b4fd-cd1a76ee9d6e/18-oss-spotlight_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>18: Community Open Source Spotlight</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:37:42</itunes:duration>
       <itunes:summary>Taking a break from Swift itself, we shine the spotlight on the open source community and highlight some lesser-known open source Swift projects that we think are interesting!</itunes:summary>
@@ -3259,7 +3259,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Thanks to this episode's sponsor, <a href="http://buddybuild.com">Buddy Build</a>: A continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams. Try it out today FREE: http://buddybuild.com</p>
 ]]></description>
       <pubDate>Mon, 26 Jun 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Testing Swift: https://github.com/apple/swift/blob/master/docs/Testing.rst</li>
@@ -3286,7 +3286,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="29883396" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4fddc14c-1844-486b-a289-d1162f2e176f/17-swift-testing_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>17: Testing Swift</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:31:03</itunes:duration>
       <itunes:summary>Exploring the many different ways in which the Swift compiler is tested.</itunes:summary>
@@ -3308,7 +3308,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 19 Jun 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Error Handling: https://github.com/apple/swift/blob/master/docs/ErrorHandling.rst</li>
@@ -3320,7 +3320,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="34711245" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3c876c5d-2686-4b2c-94c0-b722f643dbcb/16-error-handling_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>16: Error Handling in Swift — A History</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:36:05</itunes:duration>
       <itunes:summary>The state of error handling in Swift and a brief history on how we got here, as well as comparisons to Objective-C.</itunes:summary>
@@ -3347,7 +3347,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 12 Jun 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>What should you expect with Swift 4?</h3>
 <p>Some great new features and improvements.</p>
@@ -3364,7 +3364,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="29425349" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/401a9081-0886-4643-a347-2f2a20f6b384/16-what-is-new-with-swift-4-part-2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>15: What&apos;s New in Swift 4 (Part 2)</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:30:35</itunes:duration>
       <itunes:summary>Part two of our discussion on the new features and improvements in Swift 4! There were so many great things to discuss, we needed two episodes!</itunes:summary>
@@ -3394,7 +3394,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Thanks to this episode's sponsor, <a href="http://buddybuild.com">Buddy Build</a>: A continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams.</p>
 ]]></description>
       <pubDate>Mon, 5 Jun 2017 12:52:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>What should you expect with Swift 4?</h3>
 <p>Some great new features and improvements.</p>
@@ -3414,7 +3414,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="25065199" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/c73ea98e-f98e-4448-8bf2-67adcf036bca/14-what-is-new-with-swift-4-part-1_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>14: What&apos;s New in Swift 4 (Part 1)</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:02</itunes:duration>
       <itunes:summary>We discuss some of the new features and improvements in Swift 4!</itunes:summary>
@@ -3454,7 +3454,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Start a 15 day free trial today at https://kobiton.com/swiftunwrapped.</p>
 ]]></description>
       <pubDate>Mon, 29 May 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>SwiftPM iOS
@@ -3484,7 +3484,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="26505038" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b678161c-f1c3-48f9-bc6f-da9aff44f2b4/13-wwdcpredictions_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>13: WWDC Predictions</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:27:32</itunes:duration>
       <itunes:summary>We share our hopes &amp; expectations for the Swift language at WWDC 2017.</itunes:summary>
@@ -3512,7 +3512,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Start a 15 day free trial today at https://kobiton.com/swiftunwrapped.</p>
 ]]></description>
       <pubDate>Mon, 22 May 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Moving to Discourse, email from Ted: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170206/031657.html</li>
@@ -3530,7 +3530,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="25803701" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/03e313d9-9a1d-4efd-884a-e95ba545ad61/12-swift-evolution_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>12: Swift Evolution</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:48</itunes:duration>
       <itunes:summary>We debate if Swift evolution is pulling its weight, and if it&apos;s possible for Swift to remain &quot;open&quot; without  the cost.</itunes:summary>
@@ -3560,7 +3560,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Try it free today at https://www.buddybuild.com/.</p>
 ]]></description>
       <pubDate>Mon, 15 May 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>Manifesto: https://github.com/apple/swift/blob/master/docs/OwnershipManifesto.md</li>
@@ -3580,7 +3580,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="28006354" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/23ea43f5-838e-4cb4-a9e5-4db00048b40b/11-the-ownership-manifesto_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>11: Ownership Manifesto</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:29:06</itunes:duration>
       <itunes:summary>A brief overview of the complex topic of memory ownership revisions currently underway.</itunes:summary>
@@ -3622,7 +3622,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Thanks to this episode's sponsor, PerfectlySoft. Find tutorials and other content at http://perfect.org/learn.html</p>
 ]]></description>
       <pubDate>Mon, 8 May 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h1>SE-0168: Multi-line strings</h1>
 <ul>
@@ -3654,7 +3654,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="34485470" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/40579ec4-0543-4028-b5e4-57c06a3457e9/10_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>10: The Variety Show</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:47:48</itunes:duration>
       <itunes:summary>We cover 3 recent Swift Evolution proposals and the new Swift Compatibility Test Suite.</itunes:summary>
@@ -3689,7 +3689,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Thanks to this episode's sponsor, PerfectlySoft. Find tutorials and other content at http://perfect.org/learn.html</p>
 ]]></description>
       <pubDate>Mon, 1 May 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul>
 <li>String Manifesto: https://github.com/apple/swift/blob/master/docs/StringManifesto.md</li>
@@ -3714,7 +3714,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="37404160" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/29d93d56-01d6-427f-8b9b-61fb5e5928ea/09-string-manifesto_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>09: String Manifesto</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:38:53</itunes:duration>
       <itunes:summary>We go in way over our heads into Swift&apos;s String Manifesto.</itunes:summary>
@@ -3760,7 +3760,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Thanks to this episode's sponsor, PerfectlySoft. Download the Perfect Assistant for free at http://perfect.org/en/assistant/</p>
 ]]></description>
       <pubDate>Mon, 24 Apr 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h1>SE-0166: Swift Archival &amp; Serialization</h1>
 <ul>
@@ -3796,7 +3796,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="28843306" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7abb2eb7-a74f-4eef-b2af-19b360ce9afe/08-proposalreviews_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>08: Archival Serialization &amp; Swift Encoders</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:29:59</itunes:duration>
       <itunes:summary>We unpack the recent SE proposals on serialization &amp; encoding.</itunes:summary>
@@ -3836,7 +3836,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Thanks to this episode's sponsor, PerfectlySoft. Download the Perfect Assistant for free at http://perfect.org/en/assistant/</p>
 ]]></description>
       <pubDate>Mon, 17 Apr 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>Access Control Roller Coaster</h3>
 <ul>
@@ -3866,7 +3866,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="36506140" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f4d33606-5e7d-45c0-baab-16265528d571/07-access-control_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>07: Access Control - The Saga Continues</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:37:57</itunes:duration>
       <itunes:summary>There has been a ton of debate on the Swift Evolution mailing lists about access control in Swift. We share our thoughts on the situation.</itunes:summary>
@@ -3905,7 +3905,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Thanks to this episode's sponsor, PerfectlySoft. Download the Perfect Assistant for free at http://perfect.org/en/assistant/</p>
 ]]></description>
       <pubDate>Mon, 10 Apr 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>Swift 3.1 Release</h3>
 <ul>
@@ -3934,7 +3934,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="43065997" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/43598351-fe72-46a5-ac3c-c1fe7619094c/06-swift-3-1-release_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>06: Swift 3.1 Release &amp; SwiftPM Improvements</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:44:47</itunes:duration>
       <itunes:summary>This week we celebrate the release of Swift 3.1 and the large set of improvements to SwiftPM that happened just under the wire.</itunes:summary>
@@ -3981,7 +3981,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 3 Apr 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>There's been a much stronger focus on calling ObjC from Swift than the other way around, but in this talk we'll cover both directions and the parts of the Swift language involved in the process.</p>
 <h3>ObjC Interop Overview</h3>
@@ -4018,7 +4018,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="39221495" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4d4cb17a-c90c-4e34-8d11-6e0170c1b839/05-objectivec-interop_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>05: Objective-C Interoperability</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:40:47</itunes:duration>
       <itunes:summary>Continuing from episode 4&apos;s take on Objective-C Bridging, in this episode we look at Objective-C interoperability.</itunes:summary>
@@ -4051,7 +4051,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 27 Mar 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Swift has evolved since 1.x to have a fluctuating amount of magic/implicit bridging from ObjC and Foundation types, sometimes going in the opposite direction towards very explicit type conversions.</p>
 <p>We've started seeing more of what the &quot;steady state&quot; looks like as Swift 3.x/4.x development matures.</p>
@@ -4074,7 +4074,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="28658447" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/924a610c-8d9a-466b-8e39-2ce293908cf4/04-bridging-with-objective-c_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>04: Bridging with Objective-C</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:39:43</itunes:duration>
       <itunes:summary>There&apos;s been a constant push and pull on ObjC bridging since Swift 1.x, trying to seek a balance but always swaying in the other direction.</itunes:summary>
@@ -4139,7 +4139,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 20 Mar 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>Every Swift developer who has migrated code bases from Swift 1.x to 2.x, or even the more tedious 2.x to 3.x knows the pain of migrating to new Swift versions.</p>
 <p>In this episode, we cover:</p>
@@ -4194,7 +4194,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="28533506" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/666053de-af16-4453-bbe1-0c3f1c434846/03-source-stability_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>03: Source Stability (What is a Source Breaking Change?)</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:29:39</itunes:duration>
       <itunes:summary>The up (and down) sides of striving for source compatibility across Swift versions. Let&apos;s rearrange some deck chairs!</itunes:summary>
@@ -4246,7 +4246,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 13 Mar 2017 12:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>In this episode, we dive into the framework we love to hate to love: SourceKit.</p>
 <p>We wrap up with an overview of method dispatch in Swift.</p>
@@ -4288,7 +4288,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="31277368" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0a8f7b8f-2786-4ee1-8d05-903664172bbd/02-sourcekit_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>02: SourceKit (Compiling by Default)</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:32:31</itunes:duration>
       <itunes:summary>The tumultuous tales of the community getting SourceKit compiling on Linux.</itunes:summary>
@@ -4325,7 +4325,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 ]]></description>
       <pubDate>Mon, 6 Mar 2017 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>In this episode we take a look at the first full year of open source Swift development and the first complete release cycle (for 3.0) that happened completely in the open. We reflect on where we've been and how we got here. We discuss the initial launch, Swift evolution, the &quot;Great Swift 3 Migration&quot;, and more!</p>
 <ul>
@@ -4352,7 +4352,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="36189257" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5ef79daf-bbc9-4654-a335-0f4f7c02bd61/01-already-only_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>01: Already &amp; Only (Swift Open Source Year in Review)</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:37:38</itunes:duration>
       <itunes:summary>A retrospective on one year of open source Swift.</itunes:summary>
@@ -4371,7 +4371,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Be sure to subscribe so you don't miss episode 01 -  airing on Monday, March 6th and be sure to check out some of the other development shows that are a part of the <a href="https://spec.fm/">Spec Network</a>.</p>
 ]]></description>
       <pubDate>Fri, 24 Feb 2017 13:00:00 +0000</pubDate>
-      <author>shows@spec.fm (Spec)</author>
+      <author>JP Simard, Jesse Squires, Spec Network, Inc.</author>
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<p>There are tons of podcasts out there about general Apple/iOS/macOS development but nothing specifically about only the Swift programming language.</p>
 <p>So, we decided to make a podcast about the Swift language and a commentary on the <a href="https://swiftweekly.github.io/">Swift Weekly Brief</a>. This podcast is a continuation on more details about Swift Weekly and our own thoughts on Swift news.</p>
@@ -4380,7 +4380,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
       <enclosure length="2640439" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4ae1942a-835e-4096-a3b1-da86ddc3c902/00-swift-unwrapped_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>00: And We&apos;re Live!</itunes:title>
-      <itunes:author>Spec</itunes:author>
+      <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:02:41</itunes:duration>
       <itunes:summary>Welcome to Swift Unwrapped!

--- a/feed.xml
+++ b/feed.xml
@@ -12,14 +12,14 @@
     <image>
       <link>https://swiftunwrapped.github.io</link>
       <title>Swift Unwrapped</title>
-      <url>https://image.simplecastcdn.com/images/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a28195f8-ab73-4040-90cf-6b0ff94bf477/3000x3000/1557116952-artwork.jpg?aid=rss_feed</url>
+      <url>https://swiftunwrapped.github.io/img/logo.jpg</url>
     </image>
     <link>https://swiftunwrapped.github.io</link>
     <itunes:type>episodic</itunes:type>
     <itunes:summary>An audio spin off of Swift Weekly Brief and discussions on the Swift programming language. </itunes:summary>
     <itunes:author>Spec, JP Simard, Jesse Squires</itunes:author>
     <itunes:explicit>no</itunes:explicit>
-    <itunes:image href="https://image.simplecastcdn.com/images/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a28195f8-ab73-4040-90cf-6b0ff94bf477/3000x3000/1557116952-artwork.jpg?aid=rss_feed"/>
+    <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
     <itunes:new-feed-url>https://feeds.simplecast.com/3pGv88mm</itunes:new-feed-url>
     <itunes:keywords>Swift, LLVM, LLDB, Clang, Compilers, iOS, macOS, tvOS, watchOS, Technology, Swift Weekly Brief, Swift Package Manager, SPM, Swift Server, Apple, SourceKit, Xcode</itunes:keywords>
     <itunes:owner>
@@ -149,7 +149,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="34345134" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b6787f56-3a6d-43cb-884e-820a1028bba1/87_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>87: Package Registries and Indexes</itunes:title>
       <itunes:author>Spec Network, Inc.</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/2715067c-341c-4704-8ff3-ab5f74ee1281/f53f606d-6e7e-480f-b270-9599a36aeb16/3000x3000/swift-unwrapped-art.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:35:42</itunes:duration>
       <itunes:summary>There&apos;s a lot happening recently in the world of package managers, registries and indexes. Let&apos;s unwrap that.</itunes:summary>
       <itunes:subtitle>There&apos;s a lot happening recently in the world of package managers, registries and indexes. Let&apos;s unwrap that.</itunes:subtitle>
@@ -171,7 +171,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="38973156" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/641073f1-f00c-4303-b83d-140a78ceab87/project-86v2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>86: Tuples</itunes:title>
       <itunes:author>Spec Network, Inc.</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/2715067c-341c-4704-8ff3-ab5f74ee1281/2fa51834-b88e-4197-a2ad-025dc36e4a30/3000x3000/swift-unwrapped-art.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:40:32</itunes:duration>
       <itunes:summary>Is it pronounced &quot;Tuple&quot; or &quot;Tuple&quot;?</itunes:summary>
       <itunes:subtitle>Is it pronounced &quot;Tuple&quot; or &quot;Tuple&quot;?</itunes:subtitle>
@@ -221,7 +221,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="12276069" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8f254c9e-ffbc-438c-850e-2c09480eb5a5/85-swiftonwindowsv2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>85: Swift on Windows and other news</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8f254c9e-ffbc-438c-850e-2c09480eb5a5/3000x3000/1583089818-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:25:26</itunes:duration>
       <itunes:summary>Swift Foundation is now building on Windows and passing all tests, interop with C++ is being discussed on the forums, and new Swift libraries are available.</itunes:summary>
       <itunes:subtitle>Swift Foundation is now building on Windows and passing all tests, interop with C++ is being discussed on the forums, and new Swift libraries are available.</itunes:subtitle>
@@ -271,7 +271,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="31512580" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/34c97512-6201-477a-a478-b74d6ac2a7fd/84-swiftworldtour_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>84: Swift World Tour 2020</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/34c97512-6201-477a-a478-b74d6ac2a7fd/3000x3000/1580427888-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:32:45</itunes:duration>
       <itunes:summary>We discuss recent news, evolution proposals, and Swift 6</itunes:summary>
       <itunes:subtitle>We discuss recent news, evolution proposals, and Swift 6</itunes:subtitle>
@@ -307,7 +307,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="30742914" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/94ee22bc-9244-4aea-9145-d1b776f3888e/83-modifyaccessors_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>83: Modify Accessors</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/94ee22bc-9244-4aea-9145-d1b776f3888e/3000x3000/1578113303-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:31:54</itunes:duration>
       <itunes:summary>We discuss a recent Swift Evolution pitch from Ben Cohen on Modify Accessors.</itunes:summary>
       <itunes:subtitle>We discuss a recent Swift Evolution pitch from Ben Cohen on Modify Accessors.</itunes:subtitle>
@@ -355,7 +355,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="34621040" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/2c2ea7b8-9cd0-45ff-bae2-966977d4ab74/82_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>82: Swift&apos;s New Diagnostic Architecture</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/2c2ea7b8-9cd0-45ff-bae2-966977d4ab74/3000x3000/1575173492-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:36:00</itunes:duration>
       <itunes:summary>The way Swift reports compilation diagnostics like errors, warnings and fixits is about to improve in Swift 5.2.</itunes:summary>
       <itunes:subtitle>The way Swift reports compilation diagnostics like errors, warnings and fixits is about to improve in Swift 5.2.</itunes:subtitle>
@@ -407,7 +407,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="25413788" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5136fbe5-9c97-4779-a22b-6fe5b2961229/81_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>81: Swift Compiler Driver</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5136fbe5-9c97-4779-a22b-6fe5b2961229/3000x3000/1572712328-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:24</itunes:duration>
       <itunes:summary>Would you like some Swift in your Swift? The compiler driver is getting a shiny new implementation in Swift and there&apos;s no shortage of opportunities to contribute.</itunes:summary>
       <itunes:subtitle>Would you like some Swift in your Swift? The compiler driver is getting a shiny new implementation in Swift and there&apos;s no shortage of opportunities to contribute.</itunes:subtitle>
@@ -459,7 +459,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="28708165" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/9e3c7017-37a3-4f34-9f94-c4cbccc1871c/80_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>80: Standard Library Preview Package</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/9e3c7017-37a3-4f34-9f94-c4cbccc1871c/3000x3000/1570295313-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:29:50</itunes:duration>
       <itunes:summary>The Swift of tomorrow... today! The Standard Library Preview Package would allow you to try out upcoming Swift features before they officially ship with new language versions.</itunes:summary>
       <itunes:subtitle>The Swift of tomorrow... today! The Standard Library Preview Package would allow you to try out upcoming Swift features before they officially ship with new language versions.</itunes:subtitle>
@@ -505,7 +505,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="50234723" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e4296fcf-b739-4226-9cdd-1cdaf34bae5c/79_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>79: Swift 5.1 with Doug Gregor</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e4296fcf-b739-4226-9cdd-1cdaf34bae5c/3000x3000/1568513968-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:52:16</itunes:duration>
       <itunes:summary>We invite special guest, Doug Gregor, back to the show to discuss all things Swift 5.1</itunes:summary>
       <itunes:subtitle>We invite special guest, Doug Gregor, back to the show to discuss all things Swift 5.1</itunes:subtitle>
@@ -551,7 +551,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="28831488" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e3a1605d-aa61-483c-b135-dd39c75bc077/78_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>78: Binary Dependencies in Swift Package Manager</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e3a1605d-aa61-483c-b135-dd39c75bc077/3000x3000/1567297343-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:29:58</itunes:duration>
       <itunes:summary>What&apos;s one feature missing from the Swift Package Manager that CocoaPods has had for years? Binary dependencies! But how would this work in SPM?</itunes:summary>
       <itunes:subtitle>What&apos;s one feature missing from the Swift Package Manager that CocoaPods has had for years? Binary dependencies! But how would this work in SPM?</itunes:subtitle>
@@ -603,7 +603,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="24446216" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a6992481-1ec7-4d05-a4d2-1d57cd6f520a/77_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>77: Generic Math Functions and Approximate Equality</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a6992481-1ec7-4d05-a4d2-1d57cd6f520a/3000x3000/1564796280-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:25:24</itunes:duration>
       <itunes:summary>We discuss the new generic math functions coming to Swift, as well as approximate equality for floating point numbers.</itunes:summary>
       <itunes:subtitle>We discuss the new generic math functions coming to Swift, as well as approximate equality for floating point numbers.</itunes:subtitle>
@@ -671,7 +671,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="30380815" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/234e904c-9511-47ee-9fa8-658b58c60878/76_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>76: Property Wrappers</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/234e904c-9511-47ee-9fa8-658b58c60878/3000x3000/1561865782-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:31:34</itunes:duration>
       <itunes:summary>A concept that&apos;s been in and out of conversation for Swift since 2015, property behaviors - uh, delegates - uh, wrappers - are now back with the full weight of SwiftUI behind it.</itunes:summary>
       <itunes:subtitle>A concept that&apos;s been in and out of conversation for Swift since 2015, property behaviors - uh, delegates - uh, wrappers - are now back with the full weight of SwiftUI behind it.</itunes:subtitle>
@@ -733,7 +733,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="26943019" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/bad49a09-7e7d-442f-984f-3234da02fa5a/75-build-systems-w-keith-smiley_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>75: Swift Build Systems w/ Keith Smiley</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/bad49a09-7e7d-442f-984f-3234da02fa5a/3000x3000/1559446118-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:27:59</itunes:duration>
       <itunes:summary>In this episode with special guest Keith Smiley, we cover the growing number of  tools that let you build things in Swift, a few of which are made by Apple, as well as some others like CMake, Bazel and Buck.</itunes:summary>
       <itunes:subtitle>In this episode with special guest Keith Smiley, we cover the growing number of  tools that let you build things in Swift, a few of which are made by Apple, as well as some others like CMake, Bazel and Buck.</itunes:subtitle>
@@ -799,7 +799,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="33463274" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/6a1f3e80-2343-4c5e-ac0e-53a8ceea62b5/74_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>74: Removing Things From Swift</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/6a1f3e80-2343-4c5e-ac0e-53a8ceea62b5/3000x3000/1557116919-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:34:47</itunes:duration>
       <itunes:summary>Although we usually discuss new features being added to Swift, this episode is all about removing things from the language.</itunes:summary>
       <itunes:subtitle>Although we usually discuss new features being added to Swift, this episode is all about removing things from the language.</itunes:subtitle>
@@ -857,7 +857,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="25377849" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7e3b0edd-7187-4200-93a7-fb04b40598cf/project-73_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>73: UTF-8 Strings in Swift 5</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7e3b0edd-7187-4200-93a7-fb04b40598cf/3000x3000/1553811506-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:22</itunes:duration>
       <itunes:summary></itunes:summary>
       <itunes:subtitle></itunes:subtitle>
@@ -925,7 +925,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="38831987" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/187ac56a-0044-47bb-bd37-cf08d274ae77/72-official-styleguide-and-formatter_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>72: Pitch for Official Style Guide &amp; Formatter for Swift</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/187ac56a-0044-47bb-bd37-cf08d274ae77/3000x3000/1551583593-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:40:22</itunes:duration>
       <itunes:summary>In what is sure to lead to significant community discussion, there&apos;s now a pitch for adding a style guide and formatter to Swift.
 ​</itunes:summary>
@@ -997,7 +997,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="27475088" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b06bf92c-00f5-48d3-bb43-b3eaae14c4fd/71-key-path-expressions-as-functional-dependencies_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>71: Key Path Expressions as Functions</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b06bf92c-00f5-48d3-bb43-b3eaae14c4fd/3000x3000/1548821422-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:28:33</itunes:duration>
       <itunes:summary>If this proposal is accepted, we&apos;ll be seeing Key Paths in a lot more places.</itunes:summary>
       <itunes:subtitle>If this proposal is accepted, we&apos;ll be seeing Key Paths in a lot more places.</itunes:subtitle>
@@ -1057,7 +1057,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="19523053" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8cdd945e-9641-42a4-a8ba-7b79fc8f3404/70-sourcekit-lsp_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>70: SourceKit-LSP</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8cdd945e-9641-42a4-a8ba-7b79fc8f3404/3000x3000/1546304987-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:20:16</itunes:duration>
       <itunes:summary>The Swift project is working on official support for the industry-standard Language Server Protocol and we can barely contain our excitement.</itunes:summary>
       <itunes:subtitle>The Swift project is working on official support for the industry-standard Language Server Protocol and we can barely contain our excitement.</itunes:subtitle>
@@ -1097,7 +1097,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="24471594" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/43ae0c67-df77-48fb-8591-b7595e53661e/69-proposal-to-add-restult_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>69: Result</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/43ae0c67-df77-48fb-8591-b7595e53661e/3000x3000/1543733633-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:25:25</itunes:duration>
       <itunes:summary>It&apos;s the most wonderful time of the year again... the time when the Swift community considers adding a Result type to the standard library. Except that this time it&apos;ll probably work!</itunes:summary>
       <itunes:subtitle>It&apos;s the most wonderful time of the year again... the time when the Swift community considers adding a Result type to the standard library. Except that this time it&apos;ll probably work!</itunes:subtitle>
@@ -1137,7 +1137,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="15809542" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/033cae49-ad27-456e-b678-c2c062191461/68-opaque-result-types_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>68: Opaque Result Types</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/033cae49-ad27-456e-b678-c2c062191461/3000x3000/1541382828-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:16:24</itunes:duration>
       <itunes:summary>In this episode, Jesse and JP dive in to opaque result types, which could help prevent leaking of implementation details to library consumers.</itunes:summary>
       <itunes:subtitle>In this episode, Jesse and JP dive in to opaque result types, which could help prevent leaking of implementation details to library consumers.</itunes:subtitle>
@@ -1183,7 +1183,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="27169628" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/41fe97d1-9d3e-43a5-9691-25bdd82c0779/67-raw-string_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>67: Raw Strings</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/41fe97d1-9d3e-43a5-9691-25bdd82c0779/3000x3000/1539555179-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:28:14</itunes:duration>
       <itunes:summary>String literals are the gift that keep on giving with each Swift version, and Swift 5 is no exception, with raw strings.</itunes:summary>
       <itunes:subtitle>String literals are the gift that keep on giving with each Swift version, and Swift 5 is no exception, with raw strings.</itunes:subtitle>
@@ -1221,7 +1221,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="32794939" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8ba0546f-7f40-4469-a211-1027b5ac86e2/project-66_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>66: Plan For Module Stability</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8ba0546f-7f40-4469-a211-1027b5ac86e2/3000x3000/1534610922-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:34:06</itunes:duration>
       <itunes:summary>We discuss Jordan Rose&apos;s recent forums post on a proposed plan for module stability.</itunes:summary>
       <itunes:subtitle>We discuss Jordan Rose&apos;s recent forums post on a proposed plan for module stability.</itunes:subtitle>
@@ -1257,7 +1257,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="9516326" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a79347e7-d080-48db-9e7a-dec3f1426db5/65-literal-initialization-via-coercion_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>65: Literal Initialization Via Coercion</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a79347e7-d080-48db-9e7a-dec3f1426db5/3000x3000/1529888289-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:09:50</itunes:duration>
       <itunes:summary>A recent type checking speedup had very small source compatibility breakages, but nonetheless went through the evolution process and it was accepted!</itunes:summary>
       <itunes:subtitle>A recent type checking speedup had very small source compatibility breakages, but nonetheless went through the evolution process and it was accepted!</itunes:subtitle>
@@ -1295,7 +1295,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="30937092" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f7b9fbd4-a09e-4457-9abe-39458e2dcebe/64-never_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>64: Never</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f7b9fbd4-a09e-4457-9abe-39458e2dcebe/3000x3000/1529787373-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:32:09</itunes:duration>
       <itunes:summary>The Never type has some very unique properties and behavior. We introduce the type and discuss a recent proposal (SE-215) to make it conform to Hashable and Equatable.</itunes:summary>
       <itunes:subtitle>The Never type has some very unique properties and behavior. We introduce the type and discuss a recent proposal (SE-215) to make it conform to Hashable and Equatable.</itunes:subtitle>
@@ -1337,7 +1337,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="43470224" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5dcadaf5-0987-4564-9ed9-c21e5e94dcbf/61-swift-algorithms-and-data-structures-with-kelvin-lau-and-vincent-ngo_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>63: Swift algorithms and data structures (feat. Kelvin Lau &amp; Vincent Ngo)</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5dcadaf5-0987-4564-9ed9-c21e5e94dcbf/3000x3000/1526582587-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:45:12</itunes:duration>
       <itunes:summary>We welcome Kelvin and Vincent to the show to discuss Data Structures and Algorithms in Swift.</itunes:summary>
       <itunes:subtitle>We welcome Kelvin and Vincent to the show to discuss Data Structures and Algorithms in Swift.</itunes:subtitle>
@@ -1371,7 +1371,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="47236284" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e58dbe9c-430e-48e5-8444-65f5d2da5100/ted-kremenek_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>62: Interview with Ted Kremenek</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e58dbe9c-430e-48e5-8444-65f5d2da5100/3000x3000/1528594721-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:49:08</itunes:duration>
       <itunes:summary>An in-depth conversation about Swift 4.2 and beyond with Ted Kremenek, Manager of the Languages and Runtimes team at Apple.</itunes:summary>
       <itunes:subtitle>An in-depth conversation about Swift 4.2 and beyond with Ted Kremenek, Manager of the Languages and Runtimes team at Apple.</itunes:subtitle>
@@ -1413,7 +1413,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="41929152" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4420cdd7-d9ec-4285-b5fe-6811040df5c8/61-greg-heo-swiftunwrapped_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>61: WWDC reactions with Greg Heo</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4420cdd7-d9ec-4285-b5fe-6811040df5c8/3000x3000/1528513841-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:43:36</itunes:duration>
       <itunes:summary>We discuss the announcements from WWDC 2018 with special guest, Greg Heo.</itunes:summary>
       <itunes:subtitle>We discuss the announcements from WWDC 2018 with special guest, Greg Heo.</itunes:subtitle>
@@ -1463,7 +1463,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="17403646" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/ec245c2f-8cc8-45ee-ac90-c66da8811a30/60-character-properties_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>60: Character Properties</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/ec245c2f-8cc8-45ee-ac90-c66da8811a30/3000x3000/1526069364-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:18:03</itunes:duration>
       <itunes:summary>We discuss recent proposals on adding unicode properties to characters and Unicode.scalar.</itunes:summary>
       <itunes:subtitle>We discuss recent proposals on adding unicode properties to characters and Unicode.scalar.</itunes:subtitle>
@@ -1505,7 +1505,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="23458019" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/9d7fa712-39ad-457a-b090-ff4deabe88a2/59-escaping-closures_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>59: Implicit Escaping of Closures</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/9d7fa712-39ad-457a-b090-ff4deabe88a2/3000x3000/1526069281-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:24:22</itunes:duration>
       <itunes:summary>Escaping or non-escaping? That is the question.</itunes:summary>
       <itunes:subtitle>Escaping or non-escaping? That is the question.</itunes:subtitle>
@@ -1549,7 +1549,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="15924548" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/642a1037-d1c2-47a5-9d34-5e0abcb68a77/58-reimplementation-of-implicitly-unwrapped-optionals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>58: Reimplementation of Implicitly Unwrapped Optionals</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/642a1037-d1c2-47a5-9d34-5e0abcb68a77/3000x3000/1525820611-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:16:31</itunes:duration>
       <itunes:summary>IUOs are dead, long live IUOs! With this change, IUOs are no longer a type but rather a special variant of Optional.</itunes:summary>
       <itunes:subtitle>IUOs are dead, long live IUOs! With this change, IUOs are no longer a type but rather a special variant of Optional.</itunes:subtitle>
@@ -1605,7 +1605,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="39065281" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d987c101-6a78-4ae8-80c7-295b7ca5fad8/57-revisiting-tensorflow_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>57: Swift for TensorFlow Design Overview</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d987c101-6a78-4ae8-80c7-295b7ca5fad8/3000x3000/1525286307-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:40:37</itunes:duration>
       <itunes:summary>Now that Swift for TensorFlow has been open sourced and documentation is available, we share some very interesting findings.</itunes:summary>
       <itunes:subtitle>Now that Swift for TensorFlow has been open sourced and documentation is available, we share some very interesting findings.</itunes:subtitle>
@@ -1645,7 +1645,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="18527126" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5c213281-9104-498d-be10-d15b64a7b59f/56-se-206-hashable-enhancements_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>56: SE-206 Hashable Enhancements</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5c213281-9104-498d-be10-d15b64a7b59f/3000x3000/1524193202-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:19:13</itunes:duration>
       <itunes:summary>Swift will soon have a more robust hashing strategy, and it doesn&apos;t involve always returning zero for hashValue.</itunes:summary>
       <itunes:subtitle>Swift will soon have a more robust hashing strategy, and it doesn&apos;t involve always returning zero for hashValue.</itunes:subtitle>
@@ -1689,7 +1689,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="23395003" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/da8a81c5-cf62-46b1-a7c9-1bd1e5844933/55-se-202-random-unification_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>55: SE-202 Random Unification</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/da8a81c5-cf62-46b1-a7c9-1bd1e5844933/3000x3000/1524193059-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:24:18</itunes:duration>
       <itunes:summary>Randomness gets a long overdue Swift treatment.</itunes:summary>
       <itunes:subtitle>Randomness gets a long overdue Swift treatment.</itunes:subtitle>
@@ -1731,7 +1731,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="22850920" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b6a3fd5d-8692-48cc-a41b-752782516396/54-collection-sequence-proposals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>54: Collection &amp; Sequence Proposals</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b6a3fd5d-8692-48cc-a41b-752782516396/3000x3000/1522870991-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:23:44</itunes:duration>
       <itunes:summary>We cover a few recent Collection &amp; Sequence Swift Evolution proposals.</itunes:summary>
       <itunes:subtitle>We cover a few recent Collection &amp; Sequence Swift Evolution proposals.</itunes:subtitle>
@@ -1771,7 +1771,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="20855561" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/699546bf-f16a-49ed-bb6a-079ef994eb9d/53-swift-for-tensorflow_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>53: Swift for TensorFlow</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/699546bf-f16a-49ed-bb6a-079ef994eb9d/3000x3000/1522868085-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:21:39</itunes:duration>
       <itunes:summary>It happened. Google forked Swift. Swift for Tensorflow has wide-reaching implications and we just had to share our thoughts.</itunes:summary>
       <itunes:subtitle>It happened. Google forked Swift. Swift for Tensorflow has wide-reaching implications and we just had to share our thoughts.</itunes:subtitle>
@@ -1807,7 +1807,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="21807266" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/60121283-ed97-4b30-92e1-934aaa46a06f/52_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>52: Package Manager Proposals</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/60121283-ed97-4b30-92e1-934aaa46a06f/3000x3000/1522644170-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:22:38</itunes:duration>
       <itunes:summary>We cover two recent Swift Package Manager proposal pitches.</itunes:summary>
       <itunes:subtitle>We cover two recent Swift Package Manager proposal pitches.</itunes:subtitle>
@@ -1847,7 +1847,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="30822268" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b0d0ed63-d512-4910-8a6d-9ad8670be908/51-doug-and-ben-part-2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>51: Swift 4.1 w/ Doug &amp; Ben (part 2)</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b0d0ed63-d512-4910-8a6d-9ad8670be908/3000x3000/1521232730-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:32:02</itunes:duration>
       <itunes:summary>We go over the Swift 4.1 release highlights with Ben Cohen and Doug Gregor from the Swift team. Part 2 of 2.</itunes:summary>
       <itunes:subtitle>We go over the Swift 4.1 release highlights with Ben Cohen and Doug Gregor from the Swift team. Part 2 of 2.</itunes:subtitle>
@@ -1887,7 +1887,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="18147541" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/c9bed05a-df75-499f-b04c-b27aec4d8e84/50-doug-and-ben-part-1_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>50: Swift 4.1 w/ Doug &amp; Ben (part 1)</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/c9bed05a-df75-499f-b04c-b27aec4d8e84/3000x3000/1521232734-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:18:50</itunes:duration>
       <itunes:summary>We go over the Swift 4.1 release highlights with Ben Cohen and Doug Gregor from the Swift team. Part 1 of 2.</itunes:summary>
       <itunes:subtitle>We go over the Swift 4.1 release highlights with Ben Cohen and Doug Gregor from the Swift team. Part 1 of 2.</itunes:subtitle>
@@ -1919,7 +1919,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="34113985" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/eedb656b-9197-47aa-b979-f53b4770bb04/49-swift-unwrapped-protocols-wishlist_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>49: Swift Protocol Wishlist</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/eedb656b-9197-47aa-b979-f53b4770bb04/3000x3000/1519426955-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:47:17</itunes:duration>
       <itunes:summary>Thoughts on Dave DeLong&apos;s &quot;protocol wishlist&quot; for Swift and other ideas for improving Swift&apos;s protocols.</itunes:summary>
       <itunes:subtitle>Thoughts on Dave DeLong&apos;s &quot;protocol wishlist&quot; for Swift and other ideas for improving Swift&apos;s protocols.</itunes:subtitle>
@@ -1953,7 +1953,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="32448949" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/be309391-e715-4edf-a57f-4feb95fd5858/48-googlesummerofcode_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>48: Google Summer Of Code 2018</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/be309391-e715-4edf-a57f-4feb95fd5858/3000x3000/1519420967-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:33:44</itunes:duration>
       <itunes:summary>Swift.org is officially participating in the Google Summer of Code program, and there are some great project ideas.</itunes:summary>
       <itunes:subtitle>Swift.org is officially participating in the Google Summer of Code program, and there are some great project ideas.</itunes:subtitle>
@@ -2001,7 +2001,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="19570846" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/2a5c9ab9-ecd1-4211-a3b1-569ccf7775e0/47-revamp-playgrounds_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>47: Revamping QuickLook Playground APIs</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/2a5c9ab9-ecd1-4211-a3b1-569ccf7775e0/3000x3000/1517959698-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:20:19</itunes:duration>
       <itunes:summary>We discuss Connor Wakamo&apos;s proposal to revamp the Playground QuickLook APIs</itunes:summary>
       <itunes:subtitle>We discuss Connor Wakamo&apos;s proposal to revamp the Playground QuickLook APIs</itunes:subtitle>
@@ -2049,7 +2049,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="14696554" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f3757aca-5b46-47a1-9135-a162dd64c141/46-new-proposals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>46: Restricting cross-module struct initializers</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f3757aca-5b46-47a1-9135-a162dd64c141/3000x3000/1517956756-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:15:14</itunes:duration>
       <itunes:summary>We discuss Jordan Rose&apos;s proposal to address issues with struct initializers</itunes:summary>
       <itunes:subtitle>We discuss Jordan Rose&apos;s proposal to address issues with struct initializers</itunes:subtitle>
@@ -2111,7 +2111,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="25112089" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/225c62f6-62e0-4424-bad7-dd230e0b831a/45-recent-news_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>45: Swift News January 2018</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/225c62f6-62e0-4424-bad7-dd230e0b831a/3000x3000/1517017461-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:05</itunes:duration>
       <itunes:summary>The pace is picking up early 2018, so there&apos;s a lot to cover.</itunes:summary>
       <itunes:subtitle>The pace is picking up early 2018, so there&apos;s a lot to cover.</itunes:subtitle>
@@ -2141,7 +2141,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="11442722" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/88f0889d-a510-44c4-ab0f-559355cf98c2/44-swift-weekly-brief_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>44: Swift Bi-Weekly Brief</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/88f0889d-a510-44c4-ab0f-559355cf98c2/3000x3000/1516935519-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:11:51</itunes:duration>
       <itunes:summary>The King is dead, long live the King!</itunes:summary>
       <itunes:subtitle>The King is dead, long live the King!</itunes:subtitle>
@@ -2173,7 +2173,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="23289325" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d4cf620f-3176-479f-bc09-cbcdc8b650db/43-stateofstring_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>43: State of String</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d4cf620f-3176-479f-bc09-cbcdc8b650db/3000x3000/1516065258-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:24:11</itunes:duration>
       <itunes:summary>We dissect Michael Ilseman&apos;s recent document with potential optimizations and improvements to String in preparation for ABI stability.</itunes:summary>
       <itunes:subtitle>We dissect Michael Ilseman&apos;s recent document with potential optimizations and improvements to String in preparation for ABI stability.</itunes:subtitle>
@@ -2215,7 +2215,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="13334811" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7ac06d5e-4a1d-4a81-a03d-b486d4b40223/42-roadmaping_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>42: Conditional Conformance</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7ac06d5e-4a1d-4a81-a03d-b486d4b40223/3000x3000/1515717611-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:13:49</itunes:duration>
       <itunes:summary>Swift 4.1 will include support for conditional protocol conformance, and we&apos;re excited to use it!</itunes:summary>
       <itunes:subtitle>Swift 4.1 will include support for conditional protocol conformance, and we&apos;re excited to use it!</itunes:subtitle>
@@ -2247,7 +2247,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="22725539" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d3ee70a2-1165-4329-8998-b82296006fe0/41-improving-performance_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>41: Improving Compilation Performance</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d3ee70a2-1165-4329-8998-b82296006fe0/3000x3000/1513283451-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:23:36</itunes:duration>
       <itunes:summary>We discuss the recent efforts improving &amp; instrumenting the Swift compiler&apos;s performance.</itunes:summary>
       <itunes:subtitle>We discuss the recent efforts improving &amp; instrumenting the Swift compiler&apos;s performance.</itunes:subtitle>
@@ -2301,7 +2301,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="20788733" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8a89de6b-42e8-4fde-b723-1d284960eb75/40-dynamic-number-lookup-proposal_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>40: Dynamic Member Lookup Proposal</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8a89de6b-42e8-4fde-b723-1d284960eb75/3000x3000/1513054038-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:21:35</itunes:duration>
       <itunes:summary>We discuss Chris Lattner&apos;s recent &quot;Dynamic Member Lookup&quot; proposal.</itunes:summary>
       <itunes:subtitle>We discuss Chris Lattner&apos;s recent &quot;Dynamic Member Lookup&quot; proposal.</itunes:subtitle>
@@ -2335,7 +2335,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="25085608" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3e80f055-47d1-4a5f-a17c-46daae9e28fc/39-swift-source-compatibility-suite_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>39: Source Compatibility Suite Woes</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3e80f055-47d1-4a5f-a17c-46daae9e28fc/3000x3000/1512611494-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:03</itunes:duration>
       <itunes:summary>The source compatibility suite has been useful in catching compatibility issues before official Swift releases are cut, but it leaves much to be desired especially around communication with project maintainers outside Apple.</itunes:summary>
       <itunes:subtitle>The source compatibility suite has been useful in catching compatibility issues before official Swift releases are cut, but it leaves much to be desired especially around communication with project maintainers outside Apple.</itunes:subtitle>
@@ -2385,7 +2385,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="22720383" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3b3a3df2-823c-44f1-a729-b71332353d91/38-data-bases-concurrency-threading_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>38: Off to the Races</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3b3a3df2-823c-44f1-a729-b71332353d91/3000x3000/1511997574-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:23:35</itunes:duration>
       <itunes:summary>Think thread safety with Swift is the same as C languages, with slightly different syntax? Think again!</itunes:summary>
       <itunes:subtitle>Think thread safety with Swift is the same as C languages, with slightly different syntax? Think again!</itunes:subtitle>
@@ -2419,7 +2419,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="22068053" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0c2522ea-b3c8-4d72-a96b-653fdee6a484/37-enum-case-enumerable-proposal_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>37: Enum Case Enumerable Proposal</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0c2522ea-b3c8-4d72-a96b-653fdee6a484/3000x3000/1510274605-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:22:55</itunes:duration>
       <itunes:summary>Enumerate. All. The. Cases.</itunes:summary>
       <itunes:subtitle>Enumerate. All. The. Cases.</itunes:subtitle>
@@ -2461,7 +2461,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="19230976" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3ff00000-92a9-44e0-9f7a-f19dc57e3162/36-swift-evolution-topics_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>36: Swift Evolution - Current Topics &amp; Proposals</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3ff00000-92a9-44e0-9f7a-f19dc57e3162/3000x3000/1510263786-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:19:57</itunes:duration>
       <itunes:summary>Brief discussion around some recent proposals.</itunes:summary>
       <itunes:subtitle>Brief discussion around some recent proposals.</itunes:subtitle>
@@ -2513,7 +2513,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="32007984" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/da4542a6-eb11-4838-b2e6-aec756244292/35-performance-profiling-on-linux_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>35: Performance Profiling on Linux</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/da4542a6-eb11-4838-b2e6-aec756244292/3000x3000/1508459481-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:33:16</itunes:duration>
       <itunes:summary>How do you even profile without Instruments.app?</itunes:summary>
       <itunes:subtitle>How do you even profile without Instruments.app?</itunes:subtitle>
@@ -2549,7 +2549,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="21278522" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f00dfd79-3a7e-46aa-9ac5-d0147cf8597e/34-floating-point_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>34: Floating-Point</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f00dfd79-3a7e-46aa-9ac5-d0147cf8597e/3000x3000/1508373199-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:22:05</itunes:duration>
       <itunes:summary>We discuss Swift’s numeric protocols and types, especially those of the floating point variety.</itunes:summary>
       <itunes:subtitle>We discuss Swift’s numeric protocols and types, especially those of the floating point variety.</itunes:subtitle>
@@ -2615,7 +2615,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="18088665" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b535714c-2b4b-4d7e-88d8-d0bb05e85431/33-http_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>33: HTTP server v0.1.0</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b535714c-2b4b-4d7e-88d8-d0bb05e85431/3000x3000/1507250175-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:18:46</itunes:duration>
       <itunes:summary>We discuss the first release of the HTTP server library from the Swift Server APIs project.</itunes:summary>
       <itunes:subtitle>We discuss the first release of the HTTP server library from the Swift Server APIs project.</itunes:subtitle>
@@ -2655,7 +2655,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="21464943" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7ba08528-4152-4f09-a9f3-22e7beb20dab/32-migratingtoswift4_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>32: Migrating to Swift 4</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7ba08528-4152-4f09-a9f3-22e7beb20dab/3000x3000/1507247637-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:22:17</itunes:duration>
       <itunes:summary>Since many of you are probably migrating to Swift 4 as you listen to this, we figured we&apos;d share our thoughts on the transition.</itunes:summary>
       <itunes:subtitle>Since many of you are probably migrating to Swift 4 as you listen to this, we figured we&apos;d share our thoughts on the transition.</itunes:subtitle>
@@ -2715,7 +2715,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <enclosure length="24146990" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/319089de-aa5f-4d6c-892b-024e060eea48/31-compiletime_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>31: Compile Times</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/319089de-aa5f-4d6c-892b-024e060eea48/3000x3000/1506830929-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:25:05</itunes:duration>
       <itunes:summary>We share our tips for measuring &amp; improving Swift compilation times, as well as share some news about recent efforts to test compile times within the Swift repo.</itunes:summary>
       <itunes:subtitle>We share our tips for measuring &amp; improving Swift compilation times, as well as share some news about recent efforts to test compile times within the Swift repo.</itunes:subtitle>
@@ -2747,7 +2747,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="30301872" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/ce4dca05-3f4f-4c2d-8e41-8e5ded7eee7c/30-weak-references-mike-ash_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>30: Weak References with Mike Ash</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/ce4dca05-3f4f-4c2d-8e41-8e5ded7eee7c/3000x3000/1505949522-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:31:29</itunes:duration>
       <itunes:summary>We welcome Mike Ash to the show to discuss the implementation details of weak references in Swift and how they&apos;ve changed.</itunes:summary>
       <itunes:subtitle>We welcome Mike Ash to the show to discuss the implementation details of weak references in Swift and how they&apos;ve changed.</itunes:subtitle>
@@ -2783,7 +2783,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="31753901" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d6039571-6970-4994-b8d9-75d73748aa26/29-technology_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>29: Notes from Ted Kremenek, Recent Proposals &amp; Xcode 9 GM</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d6039571-6970-4994-b8d9-75d73748aa26/3000x3000/1505695068-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:33:00</itunes:duration>
       <itunes:summary>We discuss some recent Swift Evolution proposals, Xcode 9 GM, along with a boatload of Follow Up (tm) from Ted Kremenek and Pierre Habouzit.</itunes:summary>
       <itunes:subtitle>We discuss some recent Swift Evolution proposals, Xcode 9 GM, along with a boatload of Follow Up (tm) from Ted Kremenek and Pierre Habouzit.</itunes:subtitle>
@@ -2833,7 +2833,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="31734595" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/942f3e25-a7d6-4dbf-8b62-3326253070ba/28-refactoring-engine_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>28: Refactoring Engine</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/942f3e25-a7d6-4dbf-8b62-3326253070ba/3000x3000/1504986712-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:32:59</itunes:duration>
       <itunes:summary>All about the recent refactoring pieces announced at WWDC 2017 and open sourced in the last few months.</itunes:summary>
       <itunes:subtitle>All about the recent refactoring pieces announced at WWDC 2017 and open sourced in the last few months.</itunes:subtitle>
@@ -2901,7 +2901,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="57295173" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/af11f028-e749-46e7-915d-1a2d1529b939/27-chris-lattner_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>27: Concurrency with Chris Lattner</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/af11f028-e749-46e7-915d-1a2d1529b939/3000x3000/1503600803-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:59:36</itunes:duration>
       <itunes:summary>We welcome Chris Lattner to the show to discuss concurrency in Swift 5 and beyond!</itunes:summary>
       <itunes:subtitle>We welcome Chris Lattner to the show to discuss concurrency in Swift 5 and beyond!</itunes:subtitle>
@@ -2931,7 +2931,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="33417241" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b307fe79-65a0-4293-a524-d0e5e89d123c/26-swift5_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>26: Swift 5 Goals</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b307fe79-65a0-4293-a524-d0e5e89d123c/3000x3000/1503600908-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:34:44</itunes:duration>
       <itunes:summary>We share our thoughts on the newly announced goals for Swift 5.</itunes:summary>
       <itunes:subtitle>We share our thoughts on the newly announced goals for Swift 5.</itunes:subtitle>
@@ -2963,7 +2963,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="25114944" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5b31a287-ea14-436c-8d8d-4516731b2661/25-abi-stability-calling-convention-runtime-and-standard-library_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>25: ABI Stability –  Calling Convention, Runtime and Standard Library</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5b31a287-ea14-436c-8d8d-4516731b2661/3000x3000/1502834005-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:05</itunes:duration>
       <itunes:summary>The fourth and final episode in our series on ABI Stability, we cover the remaining categories of decisions that must be made to stabilize the ABI.</itunes:summary>
       <itunes:subtitle>The fourth and final episode in our series on ABI Stability, we cover the remaining categories of decisions that must be made to stabilize the ABI.</itunes:subtitle>
@@ -2999,7 +2999,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="32570478" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/bdc44b4f-6b68-4c2f-bfed-a61b1b8dfc93/24-abi-stability-mangling_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>24: ABI Stability - Mangling</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/bdc44b4f-6b68-4c2f-bfed-a61b1b8dfc93/3000x3000/1502323486-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:33:51</itunes:duration>
       <itunes:summary>Continuing our series on ABI Stability with a third installment, we focus on the mangling component and address some past mistakes.</itunes:summary>
       <itunes:subtitle>Continuing our series on ABI Stability with a third installment, we focus on the mangling component and address some past mistakes.</itunes:subtitle>
@@ -3047,7 +3047,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="36135284" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/64f4054e-fe7f-407a-90e9-54c1b42afa65/23-abi-data-layout_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>23: ABI Stability – Data Layout and Metadata</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/64f4054e-fe7f-407a-90e9-54c1b42afa65/3000x3000/1501891793-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:37:34</itunes:duration>
       <itunes:summary>Following last week&apos;s episode on the big picture of ABI Stability, we focus on two categories of decisions that need to happen to get there: data layout and metadata.</itunes:summary>
       <itunes:subtitle>Following last week&apos;s episode on the big picture of ABI Stability, we focus on two categories of decisions that need to happen to get there: data layout and metadata.</itunes:subtitle>
@@ -3077,7 +3077,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="36902185" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/96281bdf-d8a7-42b6-adc1-4d6cdc3ad58a/22-abi-stability_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>22: ABI Stability – The Big Picture</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/96281bdf-d8a7-42b6-adc1-4d6cdc3ad58a/3000x3000/1501362145-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:38:22</itunes:duration>
       <itunes:summary>We clear up some of the misconceptions around what ABI stability means, how we&apos;ll get there and why it&apos;s important.</itunes:summary>
       <itunes:subtitle>We clear up some of the misconceptions around what ABI stability means, how we&apos;ll get there and why it&apos;s important.</itunes:subtitle>
@@ -3111,7 +3111,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="26235023" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0420d3d2-6780-4313-a5b2-a77b6732d4eb/21-newproposals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>21: New Proposals</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0420d3d2-6780-4313-a5b2-a77b6732d4eb/3000x3000/1500760748-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:27:15</itunes:duration>
       <itunes:summary>This week we dive into some of the recent proposals, including SE-0180, SE-0181, SE-0182, SE-0183</itunes:summary>
       <itunes:subtitle>This week we dive into some of the recent proposals, including SE-0180, SE-0181, SE-0182, SE-0183</itunes:subtitle>
@@ -3143,7 +3143,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="28326384" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/6bd2a1e4-241b-40fb-9bb2-c3c5fe470fb3/20-swift-migrator_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>20: Swift Migrator</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/6bd2a1e4-241b-40fb-9bb2-c3c5fe470fb3/3000x3000/1499980181-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:29:26</itunes:duration>
       <itunes:summary>We dissect the newly open sourced part of Swift tooling that helps us port our apps to the latest Swift version.</itunes:summary>
       <itunes:subtitle>We dissect the newly open sourced part of Swift tooling that helps us port our apps to the latest Swift version.</itunes:subtitle>
@@ -3177,7 +3177,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="30979470" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0cc3b9b4-fe77-4261-8b07-7121aa70d8fa/22_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>19: WWDC Reactions</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0cc3b9b4-fe77-4261-8b07-7121aa70d8fa/3000x3000/1499630397-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:42:56</itunes:duration>
       <itunes:summary>A month after WWDC, we share our thoughts on the announcements and events from the week.</itunes:summary>
       <itunes:subtitle>A month after WWDC, we share our thoughts on the announcements and events from the week.</itunes:subtitle>
@@ -3223,7 +3223,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="36266469" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4e4a91d7-9e9c-45be-b4fd-cd1a76ee9d6e/18-oss-spotlight_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>18: Community Open Source Spotlight</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4e4a91d7-9e9c-45be-b4fd-cd1a76ee9d6e/3000x3000/1496791930-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:37:42</itunes:duration>
       <itunes:summary>Taking a break from Swift itself, we shine the spotlight on the open source community and highlight some lesser-known open source Swift projects that we think are interesting!</itunes:summary>
       <itunes:subtitle>Taking a break from Swift itself, we shine the spotlight on the open source community and highlight some lesser-known open source Swift projects that we think are interesting!</itunes:subtitle>
@@ -3287,7 +3287,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="29883396" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4fddc14c-1844-486b-a289-d1162f2e176f/17-swift-testing_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>17: Testing Swift</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4fddc14c-1844-486b-a289-d1162f2e176f/3000x3000/1495497709-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:31:03</itunes:duration>
       <itunes:summary>Exploring the many different ways in which the Swift compiler is tested.</itunes:summary>
       <itunes:subtitle>Exploring the many different ways in which the Swift compiler is tested.</itunes:subtitle>
@@ -3321,7 +3321,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="34711245" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3c876c5d-2686-4b2c-94c0-b722f643dbcb/16-error-handling_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>16: Error Handling in Swift — A History</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3c876c5d-2686-4b2c-94c0-b722f643dbcb/3000x3000/1496791789-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:36:05</itunes:duration>
       <itunes:summary>The state of error handling in Swift and a brief history on how we got here, as well as comparisons to Objective-C.</itunes:summary>
       <itunes:subtitle>The state of error handling in Swift and a brief history on how we got here, as well as comparisons to Objective-C.</itunes:subtitle>
@@ -3365,7 +3365,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="29425349" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/401a9081-0886-4643-a347-2f2a20f6b384/16-what-is-new-with-swift-4-part-2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>15: What&apos;s New in Swift 4 (Part 2)</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/401a9081-0886-4643-a347-2f2a20f6b384/3000x3000/1496116554-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:30:35</itunes:duration>
       <itunes:summary>Part two of our discussion on the new features and improvements in Swift 4! There were so many great things to discuss, we needed two episodes!</itunes:summary>
       <itunes:subtitle>Part two of our discussion on the new features and improvements in Swift 4! There were so many great things to discuss, we needed two episodes!</itunes:subtitle>
@@ -3415,7 +3415,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="25065199" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/c73ea98e-f98e-4448-8bf2-67adcf036bca/14-what-is-new-with-swift-4-part-1_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>14: What&apos;s New in Swift 4 (Part 1)</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/c73ea98e-f98e-4448-8bf2-67adcf036bca/3000x3000/1496116453-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:02</itunes:duration>
       <itunes:summary>We discuss some of the new features and improvements in Swift 4!</itunes:summary>
       <itunes:subtitle>We discuss some of the new features and improvements in Swift 4!</itunes:subtitle>
@@ -3485,7 +3485,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="26505038" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b678161c-f1c3-48f9-bc6f-da9aff44f2b4/13-wwdcpredictions_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>13: WWDC Predictions</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b678161c-f1c3-48f9-bc6f-da9aff44f2b4/3000x3000/1495489380-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:27:32</itunes:duration>
       <itunes:summary>We share our hopes &amp; expectations for the Swift language at WWDC 2017.</itunes:summary>
       <itunes:subtitle>We share our hopes &amp; expectations for the Swift language at WWDC 2017.</itunes:subtitle>
@@ -3531,7 +3531,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="25803701" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/03e313d9-9a1d-4efd-884a-e95ba545ad61/12-swift-evolution_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>12: Swift Evolution</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/03e313d9-9a1d-4efd-884a-e95ba545ad61/3000x3000/1494901572-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:26:48</itunes:duration>
       <itunes:summary>We debate if Swift evolution is pulling its weight, and if it&apos;s possible for Swift to remain &quot;open&quot; without  the cost.</itunes:summary>
       <itunes:subtitle>We debate if Swift evolution is pulling its weight, and if it&apos;s possible for Swift to remain &quot;open&quot; without  the cost.</itunes:subtitle>
@@ -3581,7 +3581,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="28006354" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/23ea43f5-838e-4cb4-a9e5-4db00048b40b/11-the-ownership-manifesto_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>11: Ownership Manifesto</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/23ea43f5-838e-4cb4-a9e5-4db00048b40b/3000x3000/1494376167-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:29:06</itunes:duration>
       <itunes:summary>A brief overview of the complex topic of memory ownership revisions currently underway.</itunes:summary>
       <itunes:subtitle>A brief overview of the complex topic of memory ownership revisions currently underway.</itunes:subtitle>
@@ -3655,7 +3655,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="34485470" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/40579ec4-0543-4028-b5e4-57c06a3457e9/10_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>10: The Variety Show</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/40579ec4-0543-4028-b5e4-57c06a3457e9/3000x3000/1493344262-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:47:48</itunes:duration>
       <itunes:summary>We cover 3 recent Swift Evolution proposals and the new Swift Compatibility Test Suite.</itunes:summary>
       <itunes:subtitle>We cover 3 recent Swift Evolution proposals and the new Swift Compatibility Test Suite.</itunes:subtitle>
@@ -3715,7 +3715,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="37404160" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/29d93d56-01d6-427f-8b9b-61fb5e5928ea/09-string-manifesto_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>09: String Manifesto</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/29d93d56-01d6-427f-8b9b-61fb5e5928ea/3000x3000/1492799911-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:38:53</itunes:duration>
       <itunes:summary>We go in way over our heads into Swift&apos;s String Manifesto.</itunes:summary>
       <itunes:subtitle>We go in way over our heads into Swift&apos;s String Manifesto.</itunes:subtitle>
@@ -3797,7 +3797,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="28843306" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7abb2eb7-a74f-4eef-b2af-19b360ce9afe/08-proposalreviews_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>08: Archival Serialization &amp; Swift Encoders</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7abb2eb7-a74f-4eef-b2af-19b360ce9afe/3000x3000/1492637286-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:29:59</itunes:duration>
       <itunes:summary>We unpack the recent SE proposals on serialization &amp; encoding.</itunes:summary>
       <itunes:subtitle>We unpack the recent SE proposals on serialization &amp; encoding.</itunes:subtitle>
@@ -3867,7 +3867,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="36506140" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f4d33606-5e7d-45c0-baab-16265528d571/07-access-control_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>07: Access Control - The Saga Continues</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f4d33606-5e7d-45c0-baab-16265528d571/3000x3000/1491869910-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:37:57</itunes:duration>
       <itunes:summary>There has been a ton of debate on the Swift Evolution mailing lists about access control in Swift. We share our thoughts on the situation.</itunes:summary>
       <itunes:subtitle>There has been a ton of debate on the Swift Evolution mailing lists about access control in Swift. We share our thoughts on the situation.</itunes:subtitle>
@@ -3935,7 +3935,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="43065997" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/43598351-fe72-46a5-ac3c-c1fe7619094c/06-swift-3-1-release_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>06: Swift 3.1 Release &amp; SwiftPM Improvements</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/43598351-fe72-46a5-ac3c-c1fe7619094c/3000x3000/1491278516-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:44:47</itunes:duration>
       <itunes:summary>This week we celebrate the release of Swift 3.1 and the large set of improvements to SwiftPM that happened just under the wire.</itunes:summary>
       <itunes:subtitle>This week we celebrate the release of Swift 3.1 and the large set of improvements to SwiftPM that happened just under the wire.</itunes:subtitle>
@@ -4019,7 +4019,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="39221495" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4d4cb17a-c90c-4e34-8d11-6e0170c1b839/05-objectivec-interop_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>05: Objective-C Interoperability</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4d4cb17a-c90c-4e34-8d11-6e0170c1b839/3000x3000/1488675570-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:40:47</itunes:duration>
       <itunes:summary>Continuing from episode 4&apos;s take on Objective-C Bridging, in this episode we look at Objective-C interoperability.</itunes:summary>
       <itunes:subtitle>Continuing from episode 4&apos;s take on Objective-C Bridging, in this episode we look at Objective-C interoperability.</itunes:subtitle>
@@ -4075,7 +4075,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="28658447" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/924a610c-8d9a-466b-8e39-2ce293908cf4/04-bridging-with-objective-c_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>04: Bridging with Objective-C</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/924a610c-8d9a-466b-8e39-2ce293908cf4/3000x3000/1488673934-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:39:43</itunes:duration>
       <itunes:summary>There&apos;s been a constant push and pull on ObjC bridging since Swift 1.x, trying to seek a balance but always swaying in the other direction.</itunes:summary>
       <itunes:subtitle>There&apos;s been a constant push and pull on ObjC bridging since Swift 1.x, trying to seek a balance but always swaying in the other direction.</itunes:subtitle>
@@ -4195,7 +4195,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="28533506" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/666053de-af16-4453-bbe1-0c3f1c434846/03-source-stability_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>03: Source Stability (What is a Source Breaking Change?)</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/666053de-af16-4453-bbe1-0c3f1c434846/3000x3000/1488673764-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:29:39</itunes:duration>
       <itunes:summary>The up (and down) sides of striving for source compatibility across Swift versions. Let&apos;s rearrange some deck chairs!</itunes:summary>
       <itunes:subtitle>The up (and down) sides of striving for source compatibility across Swift versions. Let&apos;s rearrange some deck chairs!</itunes:subtitle>
@@ -4289,7 +4289,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="31277368" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0a8f7b8f-2786-4ee1-8d05-903664172bbd/02-sourcekit_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>02: SourceKit (Compiling by Default)</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0a8f7b8f-2786-4ee1-8d05-903664172bbd/3000x3000/1488673610-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:32:31</itunes:duration>
       <itunes:summary>The tumultuous tales of the community getting SourceKit compiling on Linux.</itunes:summary>
       <itunes:subtitle>The tumultuous tales of the community getting SourceKit compiling on Linux.</itunes:subtitle>
@@ -4353,7 +4353,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="36189257" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5ef79daf-bbc9-4654-a335-0f4f7c02bd61/01-already-only_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>01: Already &amp; Only (Swift Open Source Year in Review)</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5ef79daf-bbc9-4654-a335-0f4f7c02bd61/3000x3000/1488673308-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:37:38</itunes:duration>
       <itunes:summary>A retrospective on one year of open source Swift.</itunes:summary>
       <itunes:subtitle>A retrospective on one year of open source Swift.</itunes:subtitle>
@@ -4381,7 +4381,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
       <enclosure length="2640439" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4ae1942a-835e-4096-a3b1-da86ddc3c902/00-swift-unwrapped_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
       <itunes:title>00: And We&apos;re Live!</itunes:title>
       <itunes:author>Spec</itunes:author>
-      <itunes:image href="https://image.simplecastcdn.com/images/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4ae1942a-835e-4096-a3b1-da86ddc3c902/3000x3000/1488077803-artwork.jpg?aid=rss_feed"/>
+      <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
       <itunes:duration>00:02:41</itunes:duration>
       <itunes:summary>Welcome to Swift Unwrapped!
 

--- a/feed.xml
+++ b/feed.xml
@@ -36,7 +36,7 @@
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul><li><a href="https://www.hackingwithswift.com/articles/233/whats-new-in-swift-5-5">Paul Hudson's What's New in Swift 5.5</a></li><li><a href="https://swiftbysundell.com/">Swift By Sundell</a></li><li><a href="https://github.com/davedelong/time">Time by Dave DeLong</a> (mistakenly called Chronos during the show)</li></ul>
 ]]></content:encoded>
-      <enclosure length="27800880" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/9415a7c4-e767-4bc1-8438-e67ff03a542c/audio/59932e5c-d516-4f64-9e02-b1923f03261d/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="27800880" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/xyd_XEwO.mp3" />
       <itunes:title>92: Deinit</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:duration>00:28:57</itunes:duration>
@@ -61,7 +61,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>Links</h3><ul><li><a href="https://forums.swift.org/t/swift-concurrency-roadmap/41611">Swift concurrency roadmap</a></li><li><a href="https://swiftunwrapped.github.io/episodes/409cbdc5/">Episode 27: Concurrency with Chris Lattner</a></li><li><a href="https://forums.swift.org/t/concurrency-actors-actor-isolation/41613">[Concurrency] Actors & actor isolation</a></li><li><a href="https://forums.swift.org/t/concurrency-interoperability-with-objective-c/41616">[Concurrency] Interoperability with Objective-C</a></li><li><a href="https://forums.swift.org/t/concurrency-structured-concurrency/41622">[Concurrency] Structured concurrency</a></li><li><a href="https://forums.swift.org/t/concurrency-asynchronous-functions/41619">[Concurrency] Asynchronous functions</a></li><li><a href="https://forums.swift.org/t/concurrency-asyncsequence/42417">[Concurrency] AsyncSequence</a></li><li><a href="https://gist.github.com/DougGregor/444575ac67cbd25bfc4b1d4fd241ae93">Swift Concurrency Proposals Dependencies Graph</a></li><li><a href="https://docs.google.com/document/d/1BEO6QwzcYCUhaGyA-WRoM_phRa7O7mGPNIMdSV4StEE">Protocol-based Actor Isolation: Draft #2</a></li><li><a href="https://forums.swift.org/t/actors-are-reference-types-but-why-classes/42281">Actors are reference types, but why classes?</a></li></ul><h3>Sponsors</h3><ul><li><strong>AWS Amplify</strong> - AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 ]]></content:encoded>
-      <enclosure length="43224292" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/0248870d-280f-4df1-8693-c659a1210f4d/audio/1e27b922-a9a5-4678-9203-a539ef1f7b58/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="43224292" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/spdcC97m.mp3" />
       <itunes:title>91: Concurrency, 3 years later</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:duration>00:44:57</itunes:duration>
@@ -82,7 +82,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h3>Links</h3><ul><li><a href="https://swift.org/blog/swift-atomics/">Announcement blog post</a></li><li><a href="https://twitter.com/lorentey/">Karoy Lorentey</a></li><li><a href="https://github.com/apple/swift-atomics">GitHub Repository</a></li><li><a href="https://forums.swift.org/c/related-projects/swift-atomics">Atomics forum</a></li><li><a href="https://news.ycombinator.com/item?id=24657500">Hacker News Discussion</a></li><li><a href="https://github.com/glessard/swift-atomics">Guillaume Lessard’s existing swift-atomics repo</a></li></ul><h3>Sponsors</h3><ul><li><strong>AWS Amplify</strong> - AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a>.</p>
 ]]></content:encoded>
-      <enclosure length="26140572" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/0d6319c6-d943-4a47-9eb0-cd58829472a8/audio/d75cc258-b633-4807-839b-49c17dc299c1/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="26140572" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/EDeUfIq2.mp3" />
       <itunes:title>90: Swift Atomics</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:duration>00:27:10</itunes:duration>
@@ -103,7 +103,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h2>What’s in a Swift runtime?</h2><ul><li><a href="https://belkadan.com/blog/2020/04/Swift-on-Mac-OS-9/">Swift on Mac OS 9</a></li><li><a href="https://belkadan.com/blog/2020/08/Swift-Runtime-Heap-Objects/">Heap Objects</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Type-Layout/">Type Layout</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Type-Metadata/">Type Metadata</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Uniquing-Caches/">Uniquing Caches</a></li><li><a href="https://belkadan.com/blog/2020/09/Swift-Runtime-Class-Metadata/">Class Metadata</a></li><li><a href="https://belkadan.com/blog/2020/10/Swift-Runtime-Class-Metadata-Initialization/">Class Metadata Initialization</a></li></ul><h3>Other links</h3><ul><li><a href="https://forums.swift.org/t/guarantee-in-memory-tuple-layout-or-dont/40122">Layout guarantees</a></li><li><a href="https://www.highcaffeinecontent.com/blog/20150124-MPW,-Carbon-and-building-Classic-Mac-OS-apps-in-OS-X">Steve Troughton-Smith’s BitPaint</a></li><li><a href="https://github.com/ksherlock/mpw">@ksherlock’s mpw</a></li><li><a href="https://mikeash.com/pyblog/friday-qa-2017-09-22-swift-4-weak-references.html">An explainer on Swift weak references</a></li></ul><h3>About Jordan</h3><ul><li><a href="https://twitter.com/UINT_MIN">Twitter @UINT_MIN</a></li><li><a href="https://belkadan.com">Belkadan</a></li><li><a href="https://citizensclimatelobby.org">Citizens’ Climate Lobby</a></li></ul><h3> </h3><h3>Sponsors</h3><ul><li><strong>Instabug</strong> - Get Application Performance Monitoring built for mobile apps and stay on top of your app quality with Instabug. Check them out and them them know we sent you at <a href="https://try.instabug.com/SwiftUnwrapped">https://try.instabug.com/SwiftUnwrapped</a></li></ul><p> </p><ul><li><strong>AWS Amplify </strong>- AWS Amplify is a suite of tools and services for iOS developers to build full stack serverless and cloud-based mobile apps. Check out our getting started Tutorial for iOS! Go to <a href="https://aws.amazon.com/getting-started/hands-on/build-ios-app-amplify/">awsamplify.info/IOS</a></li></ul><h3> </h3><h3>Get in Touch</h3><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a>.</p>
 ]]></content:encoded>
-      <enclosure length="63787048" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/episodes/4eaaf04a-3e8b-4ab7-96ca-84e0f622062f/audio/92563d7e-1b47-4c64-8aa3-e04013fb02f9/default_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="63787048" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/1DMLbJg5.mp3" />
       <itunes:title>89: Implementing the Swift Runtime in Swift, with Jordan Rose</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:duration>01:06:22</itunes:duration>
@@ -124,7 +124,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul><li><a href="https://swift.org/blog/5-3-release-process/">5.3 release process</a></li><li><a href="https://swift.org/blog/additional-linux-distros/">Swift for Linux distros</a></li><li><a href="https://swift.org/blog/aws-lambda-runtime/">AWS lambda Runtime</a></li><li><a href="https://swift.org/blog/swift-service-lifecycle/">Swift Service Lifecycle</a></li><li><a href="https://swift.org/blog/swift-cluster-membership/">Swift Cluster membership</a></li><li><a href="https://apple.github.io/swift-evolution/#?status=accepted&version=5.3">Proposals accepted/implemented in 5.3</a></li><li><a href="https://github.com/apple/swift/commits/release/5.3">Commit history for Swift 5.3 branch</a></li><li><a href="https://github.com/apple/swift/pull/33487">Mike Ash's perf PR</a></li><li><a href="https://www.hackingwithswift.com/articles/218/whats-new-in-swift-5-3">Hacking with Swift What’s New in Swift 5.3</a></li></ul><h2>Get in Touch</h2><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="17873749" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f66e20f0-f2e0-4aef-953b-3fbf60ea8dc8/88_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="17873749" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/DasaMAiV.mp3" />
       <itunes:title>88: Swift 5.3</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:duration>00:18:33</itunes:duration>
@@ -145,7 +145,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<ul><li>Swift Package Index<ul><li><a href="https://iosdevweekly.com/issues/460#comment">Intro</a></li><li><a href="https://swiftpackageindex.com">Website</a></li><li><a href="https://forums.swift.org/t/introducing-the-swift-package-index/37512">Forum</a></li><li><a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server">GitHub</a></li><li><a href="https://github.com/SwiftPackageIndex/PackageList">Package List</a></li><li><a href="https://twitter.com/daveverwer">Dave</a></li><li><a href="https://twitter.com/_sa_s">Sven</a></li><li><a href="https://cocoapods.org">CocoaPods website</a></li></ul></li><li>Swift Package Registry<ul><li><a href="https://forums.swift.org/t/swift-package-registry-service/37219">Swift Package Registry Service Pitch</a><ul><li><a href="https://twitter.com/mattt/status/1278706413921951746">Tweet</a></li></ul></li><li><a href="https://forums.swift.org/t/package-manager-source-archive-dependencies/38626">Package Manager Source Archive Dependencies Pitch</a><ul><li><a href="https://twitter.com/mattt/status/1285966688597315584">Tweet</a></li></ul></li><li><a href="https://twitter.com/mattt">Mattt Thompson</a></li></ul></li></ul><h2>Get in Touch</h2><p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p><p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="34345134" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b6787f56-3a6d-43cb-884e-820a1028bba1/87_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="34345134" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/aC5JVWoo.mp3" />
       <itunes:title>87: Package Registries and Indexes</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -167,7 +167,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
       <link>https://swiftunwrapped.github.io</link>
       <content:encoded><![CDATA[<h4>SE-0282 Tuples conform to Equatable, Comparable, and Hashable</h4><ul><li>Acceptance: <a href="https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658">https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658</a></li><li>Review: <a href="https://forums.swift.org/t/se-0283-tuples-conform-to-equatable-comparable-and-hashable/36140">https://forums.swift.org/t/se-0283-tuples-conform-to-equatable-comparable-and-hashable/36140</a></li><li>Proposal: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0283-tuples-are-equatable-comparable-hashable.md">https://github.com/apple/swift-evolution/blob/master/proposals/0283-tuples-are-equatable-comparable-hashable.md</a></li></ul><p>Bow: <a href="https://bow-swift.io">https://bow-swift.io</a></p><h3>👋 Get in Touch</h3><p>We are <a href="https://twitter.com/swift_unwrapped">@swift_unwrapped</a> on twitter. Follow us, ask us a question, let us know what you think of the show! If you want to follow us individually, we're <a href="https://twitter.com/jesse_squires">@jesse_squires</a> and <a href="https://twitter.com/simjp">@simjp</a>.</p><h3>🖤 Leave A Review</h3><p>If you're enjoying the show. The best and easiest way to show your support is by heading over to iTunes and leaving us a review! Not only do you let us know what you like about the show, but you're also helping other Swift language folks find the show.</p><p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
 ]]></content:encoded>
-      <enclosure length="38973156" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/641073f1-f00c-4303-b83d-140a78ceab87/project-86v2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="38973156" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/fxMk4ipF.mp3" />
       <itunes:title>86: Tuples</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -217,7 +217,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show. The best and easiest way to show your support is by heading over to iTunes and leaving us a review! Not only do you let us know what you like about the show, but you're also helping other Swift language folks find the show.</p>
 <p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
 ]]></content:encoded>
-      <enclosure length="12276069" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8f254c9e-ffbc-438c-850e-2c09480eb5a5/85-swiftonwindowsv2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="12276069" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/6d603539.mp3" />
       <itunes:title>85: Swift on Windows and other news</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -267,7 +267,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show. The best and easiest way to show your support is by heading over to iTunes and leaving us a review! Not only do you let us know what you like about the show, but you're also helping other Swift language folks find the show.</p>
 <p>Head over to our <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes page</a> to share your opinion of the show!</p>
 ]]></content:encoded>
-      <enclosure length="31512580" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/34c97512-6201-477a-a478-b74d6ac2a7fd/84-swiftworldtour_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="31512580" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/983844da.mp3" />
       <itunes:title>84: Swift World Tour 2020</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -303,7 +303,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="30742914" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/94ee22bc-9244-4aea-9145-d1b776f3888e/83-modifyaccessors_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="30742914" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/8f07264c.mp3" />
       <itunes:title>83: Modify Accessors</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -351,7 +351,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="34621040" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/2c2ea7b8-9cd0-45ff-bae2-966977d4ab74/82_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="34621040" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/22df931e.mp3" />
       <itunes:title>82: Swift&apos;s New Diagnostic Architecture</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -403,7 +403,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="25413788" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5136fbe5-9c97-4779-a22b-6fe5b2961229/81_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="25413788" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/96f9f099.mp3" />
       <itunes:title>81: Swift Compiler Driver</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -455,7 +455,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="28708165" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/9e3c7017-37a3-4f34-9f94-c4cbccc1871c/80_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="28708165" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/3fb2a021.mp3" />
       <itunes:title>80: Standard Library Preview Package</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -501,7 +501,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="50234723" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e4296fcf-b739-4226-9cdd-1cdaf34bae5c/79_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="50234723" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/d80e524d.mp3" />
       <itunes:title>79: Swift 5.1 with Doug Gregor</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -547,7 +547,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="28831488" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e3a1605d-aa61-483c-b135-dd39c75bc077/78_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="28831488" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/502c0857.mp3" />
       <itunes:title>78: Binary Dependencies in Swift Package Manager</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -599,7 +599,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="24446216" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a6992481-1ec7-4d05-a4d2-1d57cd6f520a/77_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="24446216" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/0bd2405c.mp3" />
       <itunes:title>77: Generic Math Functions and Approximate Equality</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -667,7 +667,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="30380815" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/234e904c-9511-47ee-9fa8-658b58c60878/76_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="30380815" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/3fdcca35.mp3" />
       <itunes:title>76: Property Wrappers</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -729,7 +729,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="26943019" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/bad49a09-7e7d-442f-984f-3234da02fa5a/75-build-systems-w-keith-smiley_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="26943019" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/99a0c58b.mp3" />
       <itunes:title>75: Swift Build Systems w/ Keith Smiley</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -795,7 +795,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="33463274" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/6a1f3e80-2343-4c5e-ac0e-53a8ceea62b5/74_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="33463274" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/e3bbe72b.mp3" />
       <itunes:title>74: Removing Things From Swift</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -853,7 +853,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="25377849" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7e3b0edd-7187-4200-93a7-fb04b40598cf/project-73_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="25377849" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/23334b91.mp3" />
       <itunes:title>73: UTF-8 Strings in Swift 5</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -921,7 +921,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="38831987" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/187ac56a-0044-47bb-bd37-cf08d274ae77/72-official-styleguide-and-formatter_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="38831987" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/c81902b1.mp3" />
       <itunes:title>72: Pitch for Official Style Guide &amp; Formatter for Swift</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -993,7 +993,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="27475088" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b06bf92c-00f5-48d3-bb43-b3eaae14c4fd/71-key-path-expressions-as-functional-dependencies_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="27475088" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/2b098627.mp3" />
       <itunes:title>71: Key Path Expressions as Functions</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1053,7 +1053,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="19523053" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8cdd945e-9641-42a4-a8ba-7b79fc8f3404/70-sourcekit-lsp_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="19523053" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/2cdb62f6.mp3" />
       <itunes:title>70: SourceKit-LSP</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1093,7 +1093,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="24471594" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/43ae0c67-df77-48fb-8591-b7595e53661e/69-proposal-to-add-restult_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="24471594" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/e7074e80.mp3" />
       <itunes:title>69: Result</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1133,7 +1133,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Instabug is the simplest yet most comprehensive bug reporting and In-app feedback SDK. JP uses it at Lyft and it's proven to be a critical tool!</p>
 <p>Now, Swift Unwrapped listeners will get a free t-shirt when they sign up at <a href="https://instabug.com/swift">https://instabug.com/swift</a>.</p>
 ]]></content:encoded>
-      <enclosure length="15809542" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/033cae49-ad27-456e-b678-c2c062191461/68-opaque-result-types_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="15809542" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/5ebe2061.mp3" />
       <itunes:title>68: Opaque Result Types</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1179,7 +1179,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Instabug is the simplest yet most comprehensive bug reporting and In-app feedback SDK. JP uses it at Lyft and it's proven to be a critical tool!</p>
 <p>Now, Swift Unwrapped listeners will get a free t-shirt when they sign up at <a href="https://instabug.com/swift">https://instabug.com/swift</a>.</p>
 ]]></content:encoded>
-      <enclosure length="27169628" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/41fe97d1-9d3e-43a5-9691-25bdd82c0779/67-raw-string_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="27169628" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/040a84c3.mp3" />
       <itunes:title>67: Raw Strings</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1217,7 +1217,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Instabug is the simplest yet most comprehensive bug reporting and In-app feedback SDK. JP uses it at Lyft and it's proven to be a critical tool!</p>
 <p>Now, Swift Unwrapped listeners will get a free t-shirt when they sign up at <a href="https://instabug.com/swift">https://instabug.com/swift</a>.</p>
 ]]></content:encoded>
-      <enclosure length="32794939" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8ba0546f-7f40-4469-a211-1027b5ac86e2/project-66_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="32794939" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/20d4b31e.mp3" />
       <itunes:title>66: Plan For Module Stability</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1253,7 +1253,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="9516326" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/a79347e7-d080-48db-9e7a-dec3f1426db5/65-literal-initialization-via-coercion_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="9516326" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/7748396d.mp3" />
       <itunes:title>65: Literal Initialization Via Coercion</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1291,7 +1291,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="30937092" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f7b9fbd4-a09e-4457-9abe-39458e2dcebe/64-never_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="30937092" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/e6f9d8e6.mp3" />
       <itunes:title>64: Never</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1333,7 +1333,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <li>Vincent Ngo: https://twitter.com/VincentNgo2</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="43470224" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5dcadaf5-0987-4564-9ed9-c21e5e94dcbf/61-swift-algorithms-and-data-structures-with-kelvin-lau-and-vincent-ngo_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="43470224" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/5375fa65.mp3" />
       <itunes:title>63: Swift algorithms and data structures (feat. Kelvin Lau &amp; Vincent Ngo)</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1367,7 +1367,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <li>Ole Begemann's &quot;What's new in Swift 4.2&quot; playground: https://github.com/ole/whats-new-in-swift-4-2</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="47236284" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/e58dbe9c-430e-48e5-8444-65f5d2da5100/ted-kremenek_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="47236284" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/839af3db.mp3" />
       <itunes:title>62: Interview with Ted Kremenek</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1409,7 +1409,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <li>https://swiftunboxed.com</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="41929152" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4420cdd7-d9ec-4285-b5fe-6811040df5c8/61-greg-heo-swiftunwrapped_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="41929152" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/d725b7da.mp3" />
       <itunes:title>61: WWDC reactions with Greg Heo</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1459,7 +1459,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <li>https://github.com/apple/swift-evolution/blob/master/proposals/0211-unicode-scalar-properties.md</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="17403646" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/ec245c2f-8cc8-45ee-ac90-c66da8811a30/60-character-properties_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="17403646" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/cef2e6bc.mp3" />
       <itunes:title>60: Character Properties</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1501,7 +1501,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Now, Swift Unwrapped listeners will get a 20% discount on all paid plans, use promo-code: <strong>unwrapped2018</strong></p>
 <p>Check them out, use that promo code and get 20% off at <a href="https://instabug.com/swift">https://instabug.com/swift</a></p>
 ]]></content:encoded>
-      <enclosure length="23458019" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/9d7fa712-39ad-457a-b090-ff4deabe88a2/59-escaping-closures_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="23458019" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/62272338.mp3" />
       <itunes:title>59: Implicit Escaping of Closures</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1545,7 +1545,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="15924548" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/642a1037-d1c2-47a5-9d34-5e0abcb68a77/58-reimplementation-of-implicitly-unwrapped-optionals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="15924548" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/22af29a8.mp3" />
       <itunes:title>58: Reimplementation of Implicitly Unwrapped Optionals</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1601,7 +1601,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="39065281" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d987c101-6a78-4ae8-80c7-295b7ca5fad8/57-revisiting-tensorflow_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="39065281" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/60637761.mp3" />
       <itunes:title>57: Swift for TensorFlow Design Overview</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1641,7 +1641,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="18527126" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5c213281-9104-498d-be10-d15b64a7b59f/56-se-206-hashable-enhancements_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="18527126" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/1f9301c7.mp3" />
       <itunes:title>56: SE-206 Hashable Enhancements</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1685,7 +1685,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="23395003" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/da8a81c5-cf62-46b1-a7c9-1bd1e5844933/55-se-202-random-unification_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="23395003" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/b850afa9.mp3" />
       <itunes:title>55: SE-202 Random Unification</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1727,7 +1727,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>If you're enjoying the show and want to say thank you, the best way to do that is by <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">leaving us a review on iTunes</a>! It lets us know what you think of the show and helps us climb the charts so other people can find the show.</p>
 <p>We've also got a channel set up on Spectrum.chat! If you want to talk about today's episode, ask us a question or just follow the conversation, jump in anytime at: <a href="https://spectrum.chat/specfm/swift-unwrapped">spectrum.chat/specfm/swift-unwrapped</a></p>
 ]]></content:encoded>
-      <enclosure length="22850920" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b6a3fd5d-8692-48cc-a41b-752782516396/54-collection-sequence-proposals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="22850920" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/41e38050.mp3" />
       <itunes:title>54: Collection &amp; Sequence Proposals</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1767,7 +1767,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p>Bitrise is Mobile Continuous Integration and Delivery for your whole team, with dozens of integrations for your favourite services. Be sure to check out their new <a href="https://blog.bitrise.io/ios-auto-provision-step">iOS Auto Provision step</a> for your Xcode projects.</p>
 <p>Check them out and let them know we sent you at <a href="https://www.bitrise.io/?utm_source=swift_unwrapped_spec&amp;utm_medium=podcast&amp;utm_campaign=w15">Bitrise.io</a></p>
 ]]></content:encoded>
-      <enclosure length="20855561" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/699546bf-f16a-49ed-bb6a-079ef994eb9d/53-swift-for-tensorflow_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="20855561" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/d21a251a.mp3" />
       <itunes:title>53: Swift for TensorFlow</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1803,7 +1803,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <h3>Thank You</h3>
 <p>Thanks to this episode's sponsor, <a href="https://kobiton.com/swift/?utm_source=Swift_Unwrapped_Podcast&amp;utm_medium=Podcast&amp;utm_campaign=3.20_Swift_Unwrapped_Podcast&amp;utm_content=Free_iPhone_X">Kobiton</a>. Go to <a href="https://kobiton.com/swift/?utm_source=Swift_Unwrapped_Podcast&amp;utm_medium=Podcast&amp;utm_campaign=3.20_Swift_Unwrapped_Podcast&amp;utm_content=Free_iPhone_X">Kobiton.com/swift</a> and get your extra trial minutes!</p>
 ]]></content:encoded>
-      <enclosure length="21807266" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/60121283-ed97-4b30-92e1-934aaa46a06f/52_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="21807266" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/30f2577f.mp3" />
       <itunes:title>52: Package Manager Proposals</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1843,7 +1843,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="30822268" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b0d0ed63-d512-4910-8a6d-9ad8670be908/51-doug-and-ben-part-2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="30822268" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/901ba4e4.mp3" />
       <itunes:title>51: Swift 4.1 w/ Doug &amp; Ben (part 2)</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1883,7 +1883,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="18147541" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/c9bed05a-df75-499f-b04c-b27aec4d8e84/50-doug-and-ben-part-1_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="18147541" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/23be3a4e.mp3" />
       <itunes:title>50: Swift 4.1 w/ Doug &amp; Ben (part 1)</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1915,7 +1915,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <li>Dave DeLong on Twitter: https://twitter.com/davedelong</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="34113985" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/eedb656b-9197-47aa-b979-f53b4770bb04/49-swift-unwrapped-protocols-wishlist_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="34113985" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/aef515ab.mp3" />
       <itunes:title>49: Swift Protocol Wishlist</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1949,7 +1949,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <li>@PracticalSwift crasher PRs: https://github.com/apple/swift/pulls?q=is%3Apr+author%3Apracticalswift+is%3Aclosed</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="32448949" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/be309391-e715-4edf-a57f-4feb95fd5858/48-googlesummerofcode_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="32448949" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/4367aeeb.mp3" />
       <itunes:title>48: Google Summer Of Code 2018</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -1997,7 +1997,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="19570846" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/2a5c9ab9-ecd1-4211-a3b1-569ccf7775e0/47-revamp-playgrounds_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="19570846" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/35316396.mp3" />
       <itunes:title>47: Revamping QuickLook Playground APIs</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2045,7 +2045,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="14696554" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f3757aca-5b46-47a1-9135-a162dd64c141/46-new-proposals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="14696554" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/a8736bc8.mp3" />
       <itunes:title>46: Restricting cross-module struct initializers</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2107,7 +2107,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="25112089" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/225c62f6-62e0-4424-bad7-dd230e0b831a/45-recent-news_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="25112089" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/e682713a.mp3" />
       <itunes:title>45: Swift News January 2018</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2137,7 +2137,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="11442722" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/88f0889d-a510-44c4-ab0f-559355cf98c2/44-swift-weekly-brief_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="11442722" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/9337cd60.mp3" />
       <itunes:title>44: Swift Bi-Weekly Brief</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2169,7 +2169,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="23289325" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d4cf620f-3176-479f-bc09-cbcdc8b650db/43-stateofstring_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="23289325" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/339bc516.mp3" />
       <itunes:title>43: State of String</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2211,7 +2211,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Please leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join the conversation at http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="13334811" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7ac06d5e-4a1d-4a81-a03d-b486d4b40223/42-roadmaping_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="13334811" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/d4af5de6.mp3" />
       <itunes:title>42: Conditional Conformance</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2243,7 +2243,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="22725539" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d3ee70a2-1165-4329-8998-b82296006fe0/41-improving-performance_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="22725539" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/324c2e91.mp3" />
       <itunes:title>41: Improving Compilation Performance</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2297,7 +2297,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="20788733" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/8a89de6b-42e8-4fde-b723-1d284960eb75/40-dynamic-number-lookup-proposal_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="20788733" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/620464c0.mp3" />
       <itunes:title>40: Dynamic Member Lookup Proposal</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2331,7 +2331,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="25085608" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3e80f055-47d1-4a5f-a17c-46daae9e28fc/39-swift-source-compatibility-suite_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="25085608" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/24e5304c.mp3" />
       <itunes:title>39: Source Compatibility Suite Woes</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2381,7 +2381,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="22720383" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3b3a3df2-823c-44f1-a729-b71332353d91/38-data-bases-concurrency-threading_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="22720383" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/22a6c652.mp3" />
       <itunes:title>38: Off to the Races</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2415,7 +2415,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Leave a review on <a href="https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2">iTunes</a> and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="22068053" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0c2522ea-b3c8-4d72-a96b-653fdee6a484/37-enum-case-enumerable-proposal_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="22068053" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/852dd010.mp3" />
       <itunes:title>37: Enum Case Enumerable Proposal</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2457,7 +2457,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="19230976" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3ff00000-92a9-44e0-9f7a-f19dc57e3162/36-swift-evolution-topics_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="19230976" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/451cc858.mp3" />
       <itunes:title>36: Swift Evolution - Current Topics &amp; Proposals</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2509,7 +2509,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="32007984" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/da4542a6-eb11-4838-b2e6-aec756244292/35-performance-profiling-on-linux_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="32007984" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/8ce32daf.mp3" />
       <itunes:title>35: Performance Profiling on Linux</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2545,7 +2545,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="21278522" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f00dfd79-3a7e-46aa-9ac5-d0147cf8597e/34-floating-point_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="21278522" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/b452f159.mp3" />
       <itunes:title>34: Floating-Point</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2611,7 +2611,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="18088665" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b535714c-2b4b-4d7e-88d8-d0bb05e85431/33-http_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="18088665" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/107053e7.mp3" />
       <itunes:title>33: HTTP server v0.1.0</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2651,7 +2651,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 </ul>
 <p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="21464943" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7ba08528-4152-4f09-a9f3-22e7beb20dab/32-migratingtoswift4_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="21464943" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/791e3bc9.mp3" />
       <itunes:title>32: Migrating to Swift 4</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2711,7 +2711,7 @@ Thanks to all our listeners, guests, sponsors and the Spec network for supportin
 <p><strong>Thanks to <a href="https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped">BuddyBuild</a> for sponsoring this episode</strong>!</p>
 <p>If you're ready for free a continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams - give them a try at <a href="https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped">buddybuild.com</a> and let them know we sent you!</p>
 ]]></content:encoded>
-      <enclosure length="24146990" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/319089de-aa5f-4d6c-892b-024e060eea48/31-compiletime_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="24146990" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/f57eb2a3.mp3" />
       <itunes:title>31: Compile Times</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2743,7 +2743,7 @@ https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203?mt=2</p>
 <p>Chat with us at:<br />
 http://spectrum.chat/specfm/swift-unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="30301872" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/ce4dca05-3f4f-4c2d-8e41-8e5ded7eee7c/30-weak-references-mike-ash_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="30301872" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/5b33cc85.mp3" />
       <itunes:title>30: Weak References with Mike Ash</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2779,7 +2779,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <li>LibDispatch correction: https://twitter.com/pedantcoder/status/904951873483956225</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="31753901" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/d6039571-6970-4994-b8d9-75d73748aa26/29-technology_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="31753901" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/254085cb.mp3" />
       <itunes:title>29: Notes from Ted Kremenek, Recent Proposals &amp; Xcode 9 GM</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2829,7 +2829,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Leave a review on iTunes and join http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Thanks to BuddyBuild for sponsoring this episode: https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped</p>
 ]]></content:encoded>
-      <enclosure length="31734595" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/942f3e25-a7d6-4dbf-8b62-3326253070ba/28-refactoring-engine_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="31734595" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/9d6eaee7.mp3" />
       <itunes:title>28: Refactoring Engine</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2897,7 +2897,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="57295173" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/af11f028-e749-46e7-915d-1a2d1529b939/27-chris-lattner_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="57295173" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/409cbdc5.mp3" />
       <itunes:title>27: Concurrency with Chris Lattner</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2927,7 +2927,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 <p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
 ]]></content:encoded>
-      <enclosure length="33417241" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b307fe79-65a0-4293-a524-d0e5e89d123c/26-swift5_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="33417241" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/074b618b.mp3" />
       <itunes:title>26: Swift 5 Goals</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2959,7 +2959,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 <p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
 ]]></content:encoded>
-      <enclosure length="25114944" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5b31a287-ea14-436c-8d8d-4516731b2661/25-abi-stability-calling-convention-runtime-and-standard-library_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="25114944" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/d98ccfc2.mp3" />
       <itunes:title>25: ABI Stability –  Calling Convention, Runtime and Standard Library</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -2995,7 +2995,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 <p>Please take a minute to leave a review on iTunes (https://itunes.apple.com/us/podcast/swift-unwrapped/id1209817203) and join us on http://spectrum.chat/specfm/swift-unwrapped if you'd like to discuss the show.</p>
 ]]></content:encoded>
-      <enclosure length="32570478" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/bdc44b4f-6b68-4c2f-bfed-a61b1b8dfc93/24-abi-stability-mangling_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="32570478" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/fdbc74ca.mp3" />
       <itunes:title>24: ABI Stability - Mangling</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3043,7 +3043,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <h3>Thank You</h3>
 <p>Thanks to this episode's sponsor, <a href="https://www.buddybuild.com/?utm_source=podcast&amp;utm_medium=banner&amp;utm_campaign=swift_unwrapped&amp;utm_term=swift%20unwrapped">Buddy Build</a>: a continuous integration, continuous deployment and user feedback platform built specifically for mobile development teams. Try it out today FREE: https://www.buddybuild.com</p>
 ]]></content:encoded>
-      <enclosure length="36135284" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/64f4054e-fe7f-407a-90e9-54c1b42afa65/23-abi-data-layout_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="36135284" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/e50ce5a7.mp3" />
       <itunes:title>23: ABI Stability – Data Layout and Metadata</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3073,7 +3073,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <li>ABI Docs: https://github.com/apple/swift/blob/master/docs/ABI.rst</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="36902185" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/96281bdf-d8a7-42b6-adc1-4d6cdc3ad58a/22-abi-stability_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="36902185" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/f3cf9a35.mp3" />
       <itunes:title>22: ABI Stability – The Big Picture</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3107,7 +3107,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <li>SPM c++ support: <a href="https://github.com/apple/swift-evolution/blob/master/proposals/0181-package-manager-cpp-language-version.md">SE-0181</a></li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="26235023" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0420d3d2-6780-4313-a5b2-a77b6732d4eb/21-newproposals_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="26235023" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/7e0227d3.mp3" />
       <itunes:title>21: New Proposals</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3139,7 +3139,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <li>Migrating to Swift 4: https://swift.org/migration-guide/, https://help.apple.com/xcode/mac/current/#/deve838b19a1</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="28326384" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/6bd2a1e4-241b-40fb-9bb2-c3c5fe470fb3/20-swift-migrator_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="28326384" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/1f861221.mp3" />
       <itunes:title>20: Swift Migrator</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3173,7 +3173,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <li>Ole Begemman’s panel highlights: https://oleb.net/blog/2017/06/chris-lattner-wwdc-swift-panel/</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="30979470" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0cc3b9b4-fe77-4261-8b07-7121aa70d8fa/22_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="30979470" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/0168727e.mp3" />
       <itunes:title>19: WWDC Reactions</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3219,7 +3219,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <li>swift-lsp (in progress): https://github.com/owensd/swift-lsp</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="36266469" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4e4a91d7-9e9c-45be-b4fd-cd1a76ee9d6e/18-oss-spotlight_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="36266469" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/d6b421a4.mp3" />
       <itunes:title>18: Community Open Source Spotlight</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3283,7 +3283,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <h3>Thank You</h3>
 <p>Thanks to this episode's sponsor, <a href="http://buddybuild.com">Buddy Build</a>: A continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams. Try it out today FREE: http://buddybuild.com</p>
 ]]></content:encoded>
-      <enclosure length="29883396" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4fddc14c-1844-486b-a289-d1162f2e176f/17-swift-testing_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="29883396" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/77984302.mp3" />
       <itunes:title>17: Testing Swift</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3317,7 +3317,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <li>Typed <code>throws</code> vs not discussed in Swift Weekly Brief <a href="https://swiftweekly.github.io/issue-68/">#68</a> and <a href="https://swiftweekly.github.io/issue-51/">#51</a></li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="34711245" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/3c876c5d-2686-4b2c-94c0-b722f643dbcb/16-error-handling_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="34711245" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/90f863bd.mp3" />
       <itunes:title>16: Error Handling in Swift — A History</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3361,7 +3361,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <li><a href="https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md">Swift Evolution Proposal SE-0156: Class and Subtype existentials</a></li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="29425349" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/401a9081-0886-4643-a347-2f2a20f6b384/16-what-is-new-with-swift-4-part-2_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="29425349" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/c7b4b5ed.mp3" />
       <itunes:title>15: What&apos;s New in Swift 4 (Part 2)</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3411,7 +3411,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <h3>Thank You</h3>
 <p>Thanks to this episode's sponsor, <a href="http://buddybuild.com">Buddy Build</a>: A continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams.</p>
 ]]></content:encoded>
-      <enclosure length="25065199" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/c73ea98e-f98e-4448-8bf2-67adcf036bca/14-what-is-new-with-swift-4-part-1_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="25065199" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/fc6058df.mp3" />
       <itunes:title>14: What&apos;s New in Swift 4 (Part 1)</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3481,7 +3481,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Thanks to this episode's sponsor, <a href="https://kobiton.com/swiftunwrapped">Kobiton</a>: complete mobile device lab solution.</p>
 <p>Start a 15 day free trial today at https://kobiton.com/swiftunwrapped.</p>
 ]]></content:encoded>
-      <enclosure length="26505038" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/b678161c-f1c3-48f9-bc6f-da9aff44f2b4/13-wwdcpredictions_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="26505038" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/6eeb2070.mp3" />
       <itunes:title>13: WWDC Predictions</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3527,7 +3527,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Thanks to this episode's sponsor, <a href="https://kobiton.com/swiftunwrapped">Kobiton</a>: complete mobile device lab solution.</p>
 <p>Start a 15 day free trial today at https://kobiton.com/swiftunwrapped.</p>
 ]]></content:encoded>
-      <enclosure length="25803701" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/03e313d9-9a1d-4efd-884a-e95ba545ad61/12-swift-evolution_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="25803701" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/259160c9.mp3" />
       <itunes:title>12: Swift Evolution</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3577,7 +3577,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>Thanks to this episode's sponsor, <a href="https://www.buddybuild.com/">BuddyBuild</a>: a continuous integration, continuous deployment, and user feedback platform for iOS and Android development teams.</p>
 <p>Try it free today at https://www.buddybuild.com/.</p>
 ]]></content:encoded>
-      <enclosure length="28006354" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/23ea43f5-838e-4cb4-a9e5-4db00048b40b/11-the-ownership-manifesto_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="28006354" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/6d5d06fc.mp3" />
       <itunes:title>11: Ownership Manifesto</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3651,7 +3651,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <h3>Thank You</h3>
 <p>Thanks to this episode's sponsor, PerfectlySoft. Find tutorials and other content at http://perfect.org/learn.html</p>
 ]]></content:encoded>
-      <enclosure length="34485470" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/40579ec4-0543-4028-b5e4-57c06a3457e9/10_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="34485470" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/96773dee.mp3" />
       <itunes:title>10: The Variety Show</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3711,7 +3711,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <h3>Thank You</h3>
 <p>Thanks to this episode's sponsor, PerfectlySoft. Find tutorials and other content at http://perfect.org/learn.html</p>
 ]]></content:encoded>
-      <enclosure length="37404160" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/29d93d56-01d6-427f-8b9b-61fb5e5928ea/09-string-manifesto_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="37404160" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/01631c29.mp3" />
       <itunes:title>09: String Manifesto</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3793,7 +3793,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <h3>Thank You</h3>
 <p>Thanks to this episode's sponsor, PerfectlySoft. Download the Perfect Assistant for free at http://perfect.org/en/assistant/</p>
 ]]></content:encoded>
-      <enclosure length="28843306" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/7abb2eb7-a74f-4eef-b2af-19b360ce9afe/08-proposalreviews_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="28843306" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/1ff40107.mp3" />
       <itunes:title>08: Archival Serialization &amp; Swift Encoders</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3863,7 +3863,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>###Thank You</p>
 <p>Thanks to this episode's sponsor, PerfectlySoft. Download the Perfect Assistant for free at http://perfect.org/en/assistant/</p>
 ]]></content:encoded>
-      <enclosure length="36506140" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/f4d33606-5e7d-45c0-baab-16265528d571/07-access-control_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="36506140" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/4e7ad642.mp3" />
       <itunes:title>07: Access Control - The Saga Continues</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -3931,7 +3931,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 </ul>
 <p>Thanks to this episode's sponsor, PerfectlySoft. Download the Perfect Assistant for free at http://perfect.org/en/assistant/</p>
 ]]></content:encoded>
-      <enclosure length="43065997" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/43598351-fe72-46a5-ac3c-c1fe7619094c/06-swift-3-1-release_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="43065997" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/2b182911.mp3" />
       <itunes:title>06: Swift 3.1 Release &amp; SwiftPM Improvements</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -4015,7 +4015,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <li>Make optional requirements ObjC only: https://github.com/apple/swift-evolution/blob/master/proposals/0070-optional-requirements.md</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="39221495" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4d4cb17a-c90c-4e34-8d11-6e0170c1b839/05-objectivec-interop_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="39221495" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/115f3199.mp3" />
       <itunes:title>05: Objective-C Interoperability</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -4071,7 +4071,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <li>Conventions are useful, even if not for technical reasons. Case study with Realm trying to buck NSError ObjC conventions: https://github.com/realm/realm-cocoa/pull/1123</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="28658447" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/924a610c-8d9a-466b-8e39-2ce293908cf4/04-bridging-with-objective-c_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="28658447" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/11b58ca9.mp3" />
       <itunes:title>04: Bridging with Objective-C</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -4191,7 +4191,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <li>Tanner Nelson was behind the <code>Type.self</code> proposal, not Erica Sadun: https://github.com/apple/swift-evolution/blob/master/proposals/0090-remove-dot-self.md</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="28533506" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/666053de-af16-4453-bbe1-0c3f1c434846/03-source-stability_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="28533506" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/083dd5d3.mp3" />
       <itunes:title>03: Source Stability (What is a Source Breaking Change?)</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -4285,7 +4285,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <li><a href="http://www.jessesquires.com/avoiding-objc-in-swift/">@objc</a></li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="31277368" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/0a8f7b8f-2786-4ee1-8d05-903664172bbd/02-sourcekit_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="31277368" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/8279a6e2.mp3" />
       <itunes:title>02: SourceKit (Compiling by Default)</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -4349,7 +4349,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <li><a href="https://www.apple.com/swift/playgrounds/">Swift Playgrounds</a> for iPad</li>
 </ul>
 ]]></content:encoded>
-      <enclosure length="36189257" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/5ef79daf-bbc9-4654-a335-0f4f7c02bd61/01-already-only_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="36189257" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/b1715d76.mp3" />
       <itunes:title>01: Already &amp; Only (Swift Open Source Year in Review)</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>
@@ -4377,7 +4377,7 @@ http://spectrum.chat/specfm/swift-unwrapped</p>
 <p>If you want to connect with us you can find us and reach out on twitter: <a href="https://twitter.com/simjp">JP Simard</a> &amp; <a href="https://twitter.com/jesse_squires">Jesse Squires</a></p>
 <p>Be sure to subscribe so you don't miss episode 01 -  airing on Monday, March 6th and be sure to check out some of the other development shows that are a part of the <a href="https://spec.fm/">Spec Network</a>.</p>
 ]]></content:encoded>
-      <enclosure length="2640439" type="audio/mpeg" url="https://cdn.simplecast.com/audio/c0a958/c0a958c6-59dd-45ad-b246-1b7a1a9e51f6/4ae1942a-835e-4096-a3b1-da86ddc3c902/00-swift-unwrapped_tc.mp3?aid=rss_feed&amp;feed=3pGv88mm"/>
+      <enclosure length="2640439" type="audio/mpeg" url="https://swiftunwrapped.github.io/audio/de7f2c8e.mp3" />
       <itunes:title>00: And We&apos;re Live!</itunes:title>
       <itunes:author>JP Simard, Jesse Squires, Spec Network, Inc.</itunes:author>
       <itunes:image href="https://swiftunwrapped.github.io/img/logo.jpg"/>


### PR DESCRIPTION
Right now, this is just a dump of the feed copied from https://feeds.simplecast.com/3pGv88mm

What we need to do:

- fix up all links (most should be pretty easy find / replace)
    - [x] replace spec.fm links with this site
    - [x] replace simplecast feed links
    - [x] replace image links
    - [x] replace audio file links (this might be complicated...)
- [x] update author tags? most tags only list Spec
- make sure final feed validates
    - [x] https://podba.se/validate/
    - [x] https://castfeedvalidator.com

----

Or -- we could try to just re-generate the feed with jekyll? That might be easier -- mostly because the audio URLs don't seem to follow any sort of reasonable format. They don't use the episode IDs. 🤦🏼 

**EDIT:**

If we generate the feed ourselves, we'll need to sync additional metadata from SimpleCast, like keywords, etc. Those would need to be part of each page's front matter.

Also, I just realized, we would need to convert our pages to proper "posts" in Jekyll. That is, put them in `_posts/`. We might have to include the date in the filename (`2020-01-01-episodeID.md`) but maybe not because we include it in the front matter. We already include `permalink:` in the front matter, so URLs should "just work".

Once we have all the Front Matter and Posts, then we need to write a feed template to put it all together.